### PR TITLE
Feature/ Add parameters to GetSharedVersionsOfIdentityAttribute

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12874,7 +12874,7 @@
                 "@types/luxon": "^3.4.2"
             },
             "peerDependencies": {
-                "@nmshd/runtime": "^3.4.4"
+                "@nmshd/runtime": "^3.5.0"
             }
         },
         "packages/consumption": {
@@ -12926,7 +12926,7 @@
         },
         "packages/runtime": {
             "name": "@nmshd/runtime",
-            "version": "3.4.4",
+            "version": "3.5.0",
             "license": "MIT",
             "dependencies": {
                 "@js-soft/docdb-querytranslator": "^1.1.2",

--- a/packages/app-runtime/package.json
+++ b/packages/app-runtime/package.json
@@ -61,7 +61,7 @@
         "@types/luxon": "^3.4.2"
     },
     "peerDependencies": {
-        "@nmshd/runtime": "^3.4.4"
+        "@nmshd/runtime": "^3.5.0"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nmshd/runtime",
-    "version": "3.4.4",
+    "version": "3.5.0",
     "description": "The enmeshed client runtime.",
     "homepage": "https://enmeshed.eu",
     "repository": {

--- a/packages/runtime/src/useCases/common/RuntimeErrors.ts
+++ b/packages/runtime/src/useCases/common/RuntimeErrors.ts
@@ -166,12 +166,11 @@ class Attributes {
         );
     }
 
-    public detectedErroneousAttribute(attributeId: CoreId | string, message?: string): ApplicationError {
-        let msg = `Detected an error regarding attribute '${attributeId.toString()}'.`;
-        if (typeof message !== "undefined") {
-            msg += ` ${message}`;
-        }
-        return new ApplicationError("error.runtime.attributes.detectedErroneousAttribute", msg);
+    public noOtherVersionOfIdentityAttributeHasBeenSharedWithPeerBefore(repositoryAttributeId: CoreId | string, peer: CoreAddress | string): ApplicationError {
+        return new ApplicationError(
+            "error.runtime.attributes.noOtherVersionOfIdentityAttributeHasBeenSharedWithPeerBefore",
+            `No other version of identity attribute '${repositoryAttributeId.toString()}' has been shared with peer '${peer.toString()}' before. If you wish to execute an initial sharing of this attribute, use 'ShareIdentityAttribute'.`
+        );
     }
 }
 

--- a/packages/runtime/src/useCases/common/Schemas.ts
+++ b/packages/runtime/src/useCases/common/Schemas.ts
@@ -16948,6 +16948,15 @@ export const GetSharedVersionsOfIdentityAttributeRequest: any = {
             "properties": {
                 "attributeId": {
                     "$ref": "#/definitions/AttributeIdString"
+                },
+                "peers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/AddressString"
+                    }
+                },
+                "onlyLatestVersions": {
+                    "type": "boolean"
                 }
             },
             "required": [
@@ -16958,6 +16967,10 @@ export const GetSharedVersionsOfIdentityAttributeRequest: any = {
         "AttributeIdString": {
             "type": "string",
             "pattern": "ATT[A-Za-z0-9]{17}"
+        },
+        "AddressString": {
+            "type": "string",
+            "pattern": "id1[A-Za-z0-9]{32,33}"
         }
     }
 }

--- a/packages/runtime/src/useCases/consumption/attributes/GetSharedVersionsOfIdentityAttribute.ts
+++ b/packages/runtime/src/useCases/consumption/attributes/GetSharedVersionsOfIdentityAttribute.ts
@@ -1,13 +1,15 @@
 import { Result } from "@js-soft/ts-utils";
 import { AttributesController, LocalAttribute } from "@nmshd/consumption";
-import { CoreId } from "@nmshd/transport";
+import { CoreAddress, CoreId } from "@nmshd/transport";
 import { Inject } from "typescript-ioc";
 import { LocalAttributeDTO } from "../../../types";
-import { AttributeIdString, RuntimeErrors, SchemaRepository, SchemaValidator, UseCase } from "../../common";
+import { AddressString, AttributeIdString, RuntimeErrors, SchemaRepository, SchemaValidator, UseCase } from "../../common";
 import { AttributeMapper } from "./AttributeMapper";
 
 export interface GetSharedVersionsOfIdentityAttributeRequest {
     attributeId: AttributeIdString;
+    peers?: AddressString[];
+    onlyLatestVersions?: boolean;
 }
 
 class Validator extends SchemaValidator<GetSharedVersionsOfIdentityAttributeRequest> {
@@ -25,29 +27,20 @@ export class GetSharedVersionsOfIdentityAttributeUseCase extends UseCase<GetShar
     }
 
     protected async executeInternal(request: GetSharedVersionsOfIdentityAttributeRequest): Promise<Result<LocalAttributeDTO[]>> {
-        const attribute = await this.attributeController.getLocalAttribute(CoreId.from(request.attributeId));
+        const repositoryAttributeId = CoreId.from(request.attributeId);
+        const repositoryAttribute = await this.attributeController.getLocalAttribute(repositoryAttributeId);
 
-        if (typeof attribute === "undefined") {
+        if (typeof repositoryAttribute === "undefined") {
             throw RuntimeErrors.general.recordNotFound(LocalAttribute);
         }
 
-        if (attribute.isRelationshipAttribute()) {
-            throw RuntimeErrors.general.invalidPropertyValue("Attribute '${request.attributeId}' is a RelationshipAttribute.");
+        if (!repositoryAttribute.isRepositoryAttribute()) {
+            return Result.fail(RuntimeErrors.attributes.isNoIdentityAttribute(repositoryAttributeId));
         }
 
-        const allVersions = await this.attributeController.getVersionsOfAttribute(CoreId.from(request.attributeId));
+        const peers = request.peers?.map((address) => CoreAddress.from(address));
+        const sharedVersions = await this.attributeController.getSharedVersionsOfRepositoryAttribute(repositoryAttributeId, peers, request.onlyLatestVersions);
 
-        // queried ID doesn't belong to a repository attribute
-        if (attribute.shareInfo !== undefined) {
-            return Result.ok(AttributeMapper.toAttributeDTOList(allVersions));
-        }
-
-        const query = {
-            "shareInfo.sourceAttribute": { $in: allVersions.map((x) => x.id.toString()) }
-        };
-
-        const sharedAttributes = await this.attributeController.getLocalAttributes(query);
-
-        return Result.ok(AttributeMapper.toAttributeDTOList(sharedAttributes));
+        return Result.ok(AttributeMapper.toAttributeDTOList(sharedVersions));
     }
 }

--- a/packages/runtime/src/useCases/consumption/attributes/GetSharedVersionsOfIdentityAttribute.ts
+++ b/packages/runtime/src/useCases/consumption/attributes/GetSharedVersionsOfIdentityAttribute.ts
@@ -31,11 +31,15 @@ export class GetSharedVersionsOfIdentityAttributeUseCase extends UseCase<GetShar
         const repositoryAttribute = await this.attributeController.getLocalAttribute(repositoryAttributeId);
 
         if (typeof repositoryAttribute === "undefined") {
-            throw RuntimeErrors.general.recordNotFound(LocalAttribute);
+            return Result.fail(RuntimeErrors.general.recordNotFound(LocalAttribute));
         }
 
         if (!repositoryAttribute.isRepositoryAttribute()) {
             return Result.fail(RuntimeErrors.attributes.isNoIdentityAttribute(repositoryAttributeId));
+        }
+
+        if (request.peers?.length === 0) {
+            return Result.fail(RuntimeErrors.general.invalidPropertyValue("The `peers` property may not be an empty array."));
         }
 
         const peers = request.peers?.map((address) => CoreAddress.from(address));

--- a/packages/runtime/src/useCases/consumption/attributes/NotifyPeerAboutIdentityAttributeSuccession.ts
+++ b/packages/runtime/src/useCases/consumption/attributes/NotifyPeerAboutIdentityAttributeSuccession.ts
@@ -55,7 +55,7 @@ export class NotifyPeerAboutIdentityAttributeSuccessionUseCase extends UseCase<
             return Result.fail(RuntimeErrors.attributes.noOtherVersionOfIdentityAttributeHasBeenSharedWithPeerBefore(repositoryAttributeSuccessorId, request.peer));
         }
 
-        if (candidatePredecessors[0].shareInfo!.sourceAttribute!.toString() === request.attributeId) {
+        if (candidatePredecessors[0].shareInfo?.sourceAttribute?.toString() === request.attributeId) {
             return Result.fail(RuntimeErrors.attributes.identityAttributeHasAlreadyBeenSharedWithPeer(request.attributeId, request.peer, candidatePredecessors[0].id));
         }
 

--- a/packages/runtime/src/useCases/consumption/attributes/NotifyPeerAboutIdentityAttributeSuccession.ts
+++ b/packages/runtime/src/useCases/consumption/attributes/NotifyPeerAboutIdentityAttributeSuccession.ts
@@ -1,7 +1,7 @@
 import { Result } from "@js-soft/ts-utils";
 import { AttributesController, ConsumptionIds, IAttributeSuccessorParams, LocalAttribute } from "@nmshd/consumption";
 import { Notification, PeerSharedAttributeSucceededNotificationItem } from "@nmshd/content";
-import { AccountController, CoreId, MessageController } from "@nmshd/transport";
+import { AccountController, CoreAddress, CoreId, MessageController } from "@nmshd/transport";
 import { Inject } from "typescript-ioc";
 import { LocalAttributeDTO } from "../../../types";
 import { AddressString, AttributeIdString, RuntimeErrors, SchemaRepository, SchemaValidator, UseCase } from "../../common";
@@ -40,48 +40,27 @@ export class NotifyPeerAboutIdentityAttributeSuccessionUseCase extends UseCase<
     protected async executeInternal(request: NotifyPeerAboutIdentityAttributeSuccessionRequest): Promise<Result<NotifyPeerAboutIdentityAttributeSuccessionResponse>> {
         const repositoryAttributeSuccessorId = CoreId.from(request.attributeId);
         const repositoryAttributeSuccessor = await this.attributeController.getLocalAttribute(repositoryAttributeSuccessorId);
-        if (typeof repositoryAttributeSuccessor === "undefined") return Result.fail(RuntimeErrors.general.recordNotFound(LocalAttribute.name));
-        if (!repositoryAttributeSuccessor.isRepositoryAttribute()) return Result.fail(RuntimeErrors.attributes.isNoIdentityAttribute(repositoryAttributeSuccessor.id));
 
-        const query = {
-            "content.owner": this.accountController.identity.address.toString(),
-            "content.@type": "IdentityAttribute",
-            "shareInfo.sourceAttribute": repositoryAttributeSuccessorId.toString(),
-            "shareInfo.peer": request.peer
-        };
-        const ownSharedIdentityAttributesOfRepositoryAttributeSuccessor = await this.attributeController.getLocalAttributes(query);
-        if (ownSharedIdentityAttributesOfRepositoryAttributeSuccessor.length > 0) {
-            return Result.fail(
-                RuntimeErrors.attributes.identityAttributeHasAlreadyBeenSharedWithPeer(
-                    request.attributeId,
-                    request.peer,
-                    ownSharedIdentityAttributesOfRepositoryAttributeSuccessor[0].id
-                )
-            );
+        if (typeof repositoryAttributeSuccessor === "undefined") {
+            return Result.fail(RuntimeErrors.general.recordNotFound(LocalAttribute.name));
         }
 
-        const repositoryAttributeVersions = await this.attributeController.getVersionsOfAttribute(repositoryAttributeSuccessorId);
-        const repositoryAttributeVersionIds = repositoryAttributeVersions.map((x) => x.id.toString());
-        const candidatePredecessorsQuery: any = {
-            "shareInfo.sourceAttribute": { $in: repositoryAttributeVersionIds },
-            "shareInfo.peer": request.peer,
-            succeededBy: { $exists: false }
-        };
-        const candidatePredecessors = await this.attributeController.getLocalAttributes(candidatePredecessorsQuery);
+        if (!repositoryAttributeSuccessor.isRepositoryAttribute()) {
+            return Result.fail(RuntimeErrors.attributes.isNoIdentityAttribute(repositoryAttributeSuccessorId));
+        }
+
+        const candidatePredecessors = await this.attributeController.getSharedVersionsOfRepositoryAttribute(repositoryAttributeSuccessorId, [CoreAddress.from(request.peer)]);
 
         if (candidatePredecessors.length === 0) {
-            throw RuntimeErrors.general.recordNotFoundWithMessage(
-                "No shared predecessor found. If this is the fist version you want to share with this peer, use `ShareIdentityAttribute`."
-            );
+            return Result.fail(RuntimeErrors.attributes.noOtherVersionOfIdentityAttributeHasBeenSharedWithPeerBefore(repositoryAttributeSuccessorId, request.peer));
         }
-        if (candidatePredecessors.length > 1) {
-            throw RuntimeErrors.attributes.detectedErroneousAttribute(
-                request.attributeId,
-                "The attribute has shared copies of predecessing versions that are not in a succession chain."
-            );
+
+        if (candidatePredecessors[0].shareInfo!.sourceAttribute!.toString() === request.attributeId) {
+            return Result.fail(RuntimeErrors.attributes.identityAttributeHasAlreadyBeenSharedWithPeer(request.attributeId, request.peer, candidatePredecessors[0].id));
         }
 
         const ownSharedIdentityAttributePredecessor = candidatePredecessors[0];
+
         const notificationId = await ConsumptionIds.notification.generate();
         const successorParams: IAttributeSuccessorParams = {
             content: repositoryAttributeSuccessor.content,

--- a/packages/runtime/src/useCases/consumption/attributes/ShareIdentityAttribute.ts
+++ b/packages/runtime/src/useCases/consumption/attributes/ShareIdentityAttribute.ts
@@ -36,9 +36,16 @@ export class ShareIdentityAttributeUseCase extends UseCase<ShareIdentityAttribut
     }
 
     protected async executeInternal(request: ShareIdentityAttributeRequest): Promise<Result<LocalRequestDTO>> {
-        const repositoryAttribute = await this.attributeController.getLocalAttribute(CoreId.from(request.attributeId));
-        if (typeof repositoryAttribute === "undefined") return Result.fail(RuntimeErrors.general.recordNotFound(LocalAttribute.name));
-        if (!repositoryAttribute.isRepositoryAttribute()) return Result.fail(RuntimeErrors.attributes.isNoIdentityAttribute(repositoryAttribute.id));
+        const repositoryAttributeId = CoreId.from(request.attributeId);
+        const repositoryAttribute = await this.attributeController.getLocalAttribute(repositoryAttributeId);
+
+        if (typeof repositoryAttribute === "undefined") {
+            return Result.fail(RuntimeErrors.general.recordNotFound(LocalAttribute.name));
+        }
+
+        if (!repositoryAttribute.isRepositoryAttribute()) {
+            return Result.fail(RuntimeErrors.attributes.isNoIdentityAttribute(repositoryAttribute.id));
+        }
 
         const query = {
             "content.owner": this.accountController.identity.address.toString(),
@@ -53,45 +60,19 @@ export class ShareIdentityAttributeUseCase extends UseCase<ShareIdentityAttribut
             );
         }
 
-        let repositoryAttributeVersion = repositoryAttribute as LocalAttribute;
-        while (typeof repositoryAttributeVersion.succeededBy !== "undefined") {
-            repositoryAttributeVersion = (await this.attributeController.getLocalAttribute(repositoryAttributeVersion.succeededBy))!;
-            const query = {
-                "content.owner": this.accountController.identity.address.toString(),
-                "content.@type": "IdentityAttribute",
-                "shareInfo.sourceAttribute": repositoryAttributeVersion.id.toString(),
-                "shareInfo.peer": request.peer
-            };
-            const ownSharedIdentityAttributesOfRepositoryAttributeVersion = await this.attributeController.getLocalAttributes(query);
-            if (ownSharedIdentityAttributesOfRepositoryAttributeVersion.length > 0) {
-                return Result.fail(
-                    RuntimeErrors.attributes.anotherVersionOfIdentityAttributeHasAlreadyBeenSharedWithPeer(
-                        request.attributeId,
-                        request.peer,
-                        ownSharedIdentityAttributesOfRepositoryAttributeVersion[0].id
-                    )
-                );
-            }
-        }
-        repositoryAttributeVersion = repositoryAttribute as LocalAttribute;
-        while (typeof repositoryAttributeVersion.succeeds !== "undefined") {
-            repositoryAttributeVersion = (await this.attributeController.getLocalAttribute(repositoryAttributeVersion.succeeds))!;
-            const query = {
-                "content.owner": this.accountController.identity.address.toString(),
-                "content.@type": "IdentityAttribute",
-                "shareInfo.sourceAttribute": repositoryAttributeVersion.id.toString(),
-                "shareInfo.peer": request.peer
-            };
-            const ownSharedIdentityAttributesOfRepositoryAttributeVersion = await this.attributeController.getLocalAttributes(query);
-            if (ownSharedIdentityAttributesOfRepositoryAttributeVersion.length > 0) {
-                return Result.fail(
-                    RuntimeErrors.attributes.anotherVersionOfIdentityAttributeHasAlreadyBeenSharedWithPeer(
-                        request.attributeId,
-                        request.peer,
-                        ownSharedIdentityAttributesOfRepositoryAttributeVersion[0].id
-                    )
-                );
-            }
+        const ownSharedIdentityAttributesOfRepositoryAttributeVersion = await this.attributeController.getSharedVersionsOfRepositoryAttribute(
+            repositoryAttributeId,
+            [CoreAddress.from(request.peer)],
+            false
+        );
+        if (ownSharedIdentityAttributesOfRepositoryAttributeVersion.length > 0) {
+            return Result.fail(
+                RuntimeErrors.attributes.anotherVersionOfIdentityAttributeHasAlreadyBeenSharedWithPeer(
+                    request.attributeId,
+                    request.peer,
+                    ownSharedIdentityAttributesOfRepositoryAttributeVersion[0].id
+                )
+            );
         }
 
         const requestMetadata = request.requestMetadata ?? {};


### PR DESCRIPTION
Continuation of https://github.com/nmshd/cns-runtime/pull/191

The topic of renaming the isNoIdentityAttribute error is resolved in #9 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced new properties to enhance the retrieval of shared versions of identity attributes.
	- Added functionality to notify peers about identity attribute succession.

- **Refactor**
	- Refined error handling and logic across various attribute-related functionalities.
	- Streamlined the process for checking and sharing repository attributes.

- **Tests**
	- Expanded test coverage to include new use cases and scenarios for attribute sharing and retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->