### PR TITLE
Fix/slow query performance for dot notation queries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12926,7 +12926,7 @@
         },
         "packages/runtime": {
             "name": "@nmshd/runtime",
-            "version": "3.5.0",
+            "version": "3.5.1",
             "license": "MIT",
             "dependencies": {
                 "@js-soft/docdb-querytranslator": "^1.1.2",
@@ -12936,7 +12936,7 @@
                 "@nmshd/consumption": "3.9.2",
                 "@nmshd/content": "2.8.4",
                 "@nmshd/crypto": "2.0.5",
-                "@nmshd/transport": "2.2.1",
+                "@nmshd/transport": "2.2.2",
                 "ajv": "^8.12.0",
                 "ajv-errors": "^3.0.0",
                 "ajv-formats": "^2.1.1",
@@ -12961,7 +12961,7 @@
         },
         "packages/transport": {
             "name": "@nmshd/transport",
-            "version": "2.2.1",
+            "version": "2.2.2",
             "license": "MIT",
             "dependencies": {
                 "@js-soft/docdb-access-abstractions": "1.0.3",
@@ -14056,7 +14056,7 @@
                 "@nmshd/consumption": "3.9.2",
                 "@nmshd/content": "2.8.4",
                 "@nmshd/crypto": "2.0.5",
-                "@nmshd/transport": "2.2.1",
+                "@nmshd/transport": "2.2.2",
                 "@types/json-stringify-safe": "^5.0.3",
                 "@types/lodash": "^4.14.202",
                 "@types/luxon": "^3.4.2",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nmshd/runtime",
-    "version": "3.5.0",
+    "version": "3.5.1",
     "description": "The enmeshed client runtime.",
     "homepage": "https://enmeshed.eu",
     "repository": {
@@ -67,7 +67,7 @@
         "@nmshd/consumption": "3.9.2",
         "@nmshd/content": "2.8.4",
         "@nmshd/crypto": "2.0.5",
-        "@nmshd/transport": "2.2.1",
+        "@nmshd/transport": "2.2.2",
         "ajv": "^8.12.0",
         "ajv-errors": "^3.0.0",
         "ajv-formats": "^2.1.1",

--- a/packages/transport/package.json
+++ b/packages/transport/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nmshd/transport",
-    "version": "2.2.1",
+    "version": "2.2.2",
     "description": "The transport library handles backbone communication and content encryption.",
     "homepage": "https://enmeshed.eu",
     "repository": {

--- a/packages/transport/src/modules/relationships/RelationshipsController.ts
+++ b/packages/transport/src/modules/relationships/RelationshipsController.ts
@@ -99,14 +99,20 @@ export class RelationshipsController extends TransportController {
     }
 
     public async getRelationshipToIdentity(address: CoreAddress, status?: RelationshipStatus): Promise<Relationship | undefined> {
-        const query: any = {
-            [`${nameof<Relationship>((r) => r.peer)}.${nameof<Identity>((r) => r.address)}`]: address.toString()
-        };
+        const simpleQuery: any = { peerAddress: address.toString() };
+        const dotNotationQuery: any = { [`${nameof<Relationship>((r) => r.peer)}.${nameof<Identity>((r) => r.address)}`]: address.toString() };
+
         if (status) {
-            query[`${nameof<Relationship>((r) => r.status)}`] = status;
+            simpleQuery[`${nameof<Relationship>((r) => r.status)}`] = status;
+            dotNotationQuery[`${nameof<Relationship>((r) => r.status)}`] = status;
         }
 
-        const relationshipDoc = await this.relationships.findOne(query);
+        let relationshipDoc = await this.relationships.findOne(simpleQuery);
+
+        if (!relationshipDoc) {
+            relationshipDoc = await this.relationships.findOne(dotNotationQuery);
+        }
+
         if (!relationshipDoc) {
             return;
         }

--- a/packages/transport/src/modules/relationships/local/Relationship.ts
+++ b/packages/transport/src/modules/relationships/local/Relationship.ts
@@ -64,6 +64,8 @@ export class Relationship extends CoreSynchronizable implements IRelationship {
     public override toJSON(verbose?: boolean | undefined, serializeAsString?: boolean | undefined): any {
         const json = super.toJSON(verbose, serializeAsString) as any;
 
+        // Adds flattened peerAddress and templateId to the JSON stored in the database.
+        // This helps us to boost the performance of database queries that include these fields.
         json.peerAddress = this.peer.address.toString();
         json.templateId = this.cache?.template.id.toString();
 

--- a/packages/transport/src/modules/relationships/local/Relationship.ts
+++ b/packages/transport/src/modules/relationships/local/Relationship.ts
@@ -61,6 +61,15 @@ export class Relationship extends CoreSynchronizable implements IRelationship {
     @serialize()
     public metadataModifiedAt?: CoreDate;
 
+    public override toJSON(verbose?: boolean | undefined, serializeAsString?: boolean | undefined): any {
+        const json = super.toJSON(verbose, serializeAsString) as any;
+
+        json.peerAddress = this.peer.address.toString();
+        json.templateId = this.cache?.template.id.toString();
+
+        return json;
+    }
+
     public static fromRequestSent(id: CoreId, template: IRelationshipTemplate, peer: IIdentity, creationChange: IRelationshipChange, relationshipSecretId: CoreId): Relationship {
         const cache = CachedRelationship.from({
             changes: [creationChange],

--- a/packages/transport/src/modules/relationships/local/Relationship.ts
+++ b/packages/transport/src/modules/relationships/local/Relationship.ts
@@ -61,7 +61,7 @@ export class Relationship extends CoreSynchronizable implements IRelationship {
     @serialize()
     public metadataModifiedAt?: CoreDate;
 
-    public override toJSON(verbose?: boolean | undefined, serializeAsString?: boolean | undefined): any {
+    public override toJSON(verbose?: boolean | undefined, serializeAsString?: boolean | undefined): Object {
         const json = super.toJSON(verbose, serializeAsString) as any;
 
         // Adds flattened peerAddress and templateId to the JSON stored in the database.


### PR DESCRIPTION
As FerretDB currently has an issue with speeding up deep queries (`foo.bar = "baz"`) we have to flatten our important internal structures.

This is a first draft for speeding up `MessageController#sendMessage` which is using `RelationshipsController#getRelationshipToIdentity` internally to find the Relationship to send the Message to.

This is fully backwards compatible as we query the Relationships the old way when we don't find a Relationship with the new way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced relationship search functionality to improve accuracy based on relationship status.
	- Improved data serialization for relationships, including more detailed information in JSON format.
	- Updated search logic in the `getRelationshipToIdentity` method for better search results.
	- Added a new `toJSON` method to the `Relationship` class for improved database query performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->