### PR TITLE
Fix/make iql queries atType optional again

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12926,7 +12926,7 @@
         },
         "packages/runtime": {
             "name": "@nmshd/runtime",
-            "version": "3.5.1",
+            "version": "3.5.2",
             "license": "MIT",
             "dependencies": {
                 "@js-soft/docdb-querytranslator": "^1.1.2",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nmshd/runtime",
-    "version": "3.5.1",
+    "version": "3.5.2",
     "description": "The enmeshed client runtime.",
     "homepage": "https://enmeshed.eu",
     "repository": {

--- a/packages/runtime/src/useCases/common/Schemas.ts
+++ b/packages/runtime/src/useCases/common/Schemas.ts
@@ -15916,37 +15916,33 @@ export const ExecuteIQLQueryRequest: any = {
             "type": "object",
             "properties": {
                 "query": {
-                    "$ref": "#/definitions/IQLQueryJSON"
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "@type": {
+                            "type": "string",
+                            "const": "IQLQuery"
+                        },
+                        "queryString": {
+                            "type": "string"
+                        },
+                        "attributeCreationHints": {
+                            "$ref": "#/definitions/IQLQueryCreationHintsJSON"
+                        },
+                        "@context": {
+                            "type": "string"
+                        },
+                        "@version": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "queryString"
+                    ]
                 }
             },
             "required": [
                 "query"
-            ],
-            "additionalProperties": false
-        },
-        "IQLQueryJSON": {
-            "type": "object",
-            "properties": {
-                "@type": {
-                    "type": "string",
-                    "const": "IQLQuery"
-                },
-                "@context": {
-                    "type": "string"
-                },
-                "@version": {
-                    "type": "string"
-                },
-                "queryString": {
-                    "type": "string"
-                },
-                "attributeCreationHints": {
-                    "$ref": "#/definitions/IQLQueryCreationHintsJSON"
-                }
-            },
-            "required": [
-                "@type",
-                "queryString"
             ],
             "additionalProperties": false
         },

--- a/packages/runtime/src/useCases/consumption/attributes/ExecuteIQLQuery.ts
+++ b/packages/runtime/src/useCases/consumption/attributes/ExecuteIQLQuery.ts
@@ -7,7 +7,7 @@ import { SchemaRepository, SchemaValidator, UseCase } from "../../common";
 import { AttributeMapper } from "./AttributeMapper";
 
 export interface ExecuteIQLQueryRequest {
-    query: IQLQueryJSON;
+    query: Omit<IQLQueryJSON, "@type"> & { "@type"?: "IQLQuery" };
 }
 
 class Validator extends SchemaValidator<ExecuteIQLQueryRequest> {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the structure of the IQL query request to include new fields (`@type`, `@context`, `@version`) for improved query specificity and control.
	- Made the `queryString` property a required field within IQL query requests, ensuring queries are well-defined.
- **Refactor**
	- Updated the IQL query interface to better align with new query structure requirements, including adjustments to the `@type` field handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->