### PR TITLE
Refactor/runtime tests with new test utilities

### DIFF
--- a/packages/runtime/test/consumption/iqlQuery.test.ts
+++ b/packages/runtime/test/consumption/iqlQuery.test.ts
@@ -278,7 +278,13 @@ describe("IQL Query", () => {
 
     test("recipient: send Response via Message", async () => {
         const result = await rTransportServices.messages.sendMessage({
-            content: rLocalRequest.response!.content,
+            content: {
+                "@type": "ResponseWrapper",
+                requestId: sLocalRequest.id,
+                requestSourceReference: sRequestMessage.id,
+                requestSourceType: "Message",
+                response: rLocalRequest.response!.content
+            },
             recipients: [(await sTransportServices.account.getIdentityInfo()).value.address]
         });
 
@@ -286,7 +292,7 @@ describe("IQL Query", () => {
 
         rResponseMessage = result.value;
 
-        expect(rResponseMessage.content["@type"]).toBe("Response");
+        expect(rResponseMessage.content["@type"]).toBe("ResponseWrapper");
     });
 
     test("recipient: complete incoming Request", async () => {
@@ -322,7 +328,7 @@ describe("IQL Query", () => {
         sResponseMessage = await syncUntilHasMessageWithResponse(sTransportServices, sLocalRequest.id);
         const result = await sConsumptionServices.outgoingRequests.complete({
             messageId: sResponseMessage.id,
-            receivedResponse: sResponseMessage.content
+            receivedResponse: sResponseMessage.content.response
         });
 
         expect(result).toBeSuccessful();

--- a/packages/runtime/test/consumption/notifications.test.ts
+++ b/packages/runtime/test/consumption/notifications.test.ts
@@ -2,7 +2,14 @@ import { ConsumptionIds, LocalNotificationStatus } from "@nmshd/consumption";
 import { Notification } from "@nmshd/content";
 import { CoreIdHelper } from "@nmshd/transport";
 import { ConsumptionServices, TransportServices } from "../../src";
-import { establishRelationship, RuntimeServiceProvider, sendAndReceiveNotification, syncUntilHasMessages, TestNotificationItem, TestNotificationItemProcessor } from "../lib";
+import {
+    establishRelationship,
+    RuntimeServiceProvider,
+    sendAndReceiveNotification,
+    syncUntilHasMessageWithNotification,
+    TestNotificationItem,
+    TestNotificationItemProcessor
+} from "../lib";
 
 const runtimeServiceProvider = new RuntimeServiceProvider();
 let sTransportServices: TransportServices;
@@ -47,11 +54,11 @@ describe("Notifications", () => {
     });
 
     test("receivedNotification", async () => {
-        const notificationToSend = Notification.from({ id: await ConsumptionIds.notification.generate(), items: [TestNotificationItem.from({})] });
+        const id = await ConsumptionIds.notification.generate();
+        const notificationToSend = Notification.from({ id, items: [TestNotificationItem.from({})] });
         await sTransportServices.messages.sendMessage({ recipients: [rAddress], content: notificationToSend.toJSON() });
 
-        const messages = await syncUntilHasMessages(rTransportServices, 1);
-        const message = messages[0];
+        const message = await syncUntilHasMessageWithNotification(rTransportServices, id);
 
         const notification = await rConsumptionServices.notifications.receivedNotification({ messageId: message.id });
         expect(notification).toBeSuccessful();

--- a/packages/runtime/test/consumption/requests.test.ts
+++ b/packages/runtime/test/consumption/requests.test.ts
@@ -239,7 +239,13 @@ describe("Requests", () => {
 
         test("recipient: send Response via Message", async () => {
             const result = await rTransportServices.messages.sendMessage({
-                content: rLocalRequest.response!.content,
+                content: {
+                    "@type": "ResponseWrapper",
+                    requestId: sLocalRequest.id,
+                    requestSourceReference: sRequestMessage.id,
+                    requestSourceType: "Message",
+                    response: rLocalRequest.response!.content
+                },
                 recipients: [(await sTransportServices.account.getIdentityInfo()).value.address]
             });
 
@@ -247,7 +253,7 @@ describe("Requests", () => {
 
             rResponseMessage = result.value;
 
-            expect(rResponseMessage.content["@type"]).toBe("Response");
+            expect(rResponseMessage.content["@type"]).toBe("ResponseWrapper");
         });
 
         test("recipient: complete incoming Request", async () => {
@@ -283,7 +289,7 @@ describe("Requests", () => {
             sResponseMessage = await syncUntilHasMessageWithResponse(sTransportServices, sLocalRequest.id);
             const result = await sConsumptionServices.outgoingRequests.complete({
                 messageId: sResponseMessage.id,
-                receivedResponse: sResponseMessage.content
+                receivedResponse: sResponseMessage.content.response
             });
 
             expect(result).toBeSuccessful();

--- a/packages/runtime/test/consumption/requests.test.ts
+++ b/packages/runtime/test/consumption/requests.test.ts
@@ -14,7 +14,7 @@ import {
     TransportServices
 } from "../../src";
 import { IncomingRequestReceivedEvent, IncomingRequestStatusChangedEvent } from "../../src/events";
-import { establishRelationship, RuntimeServiceProvider, syncUntilHasMessages, syncUntilHasRelationships } from "../lib";
+import { establishRelationship, RuntimeServiceProvider, syncUntilHasMessageWithRequest, syncUntilHasMessageWithResponse, syncUntilHasRelationships } from "../lib";
 
 describe("Requests", () => {
     describe.each([
@@ -117,20 +117,13 @@ describe("Requests", () => {
             expect(triggeredEvent!.data.request.id).toBe(result.value.id);
         });
 
-        test("recipient: sync the Message with the Request", async () => {
-            const result = await syncUntilHasMessages(rTransportServices);
-
-            expect(result).toHaveLength(1);
-
-            rRequestMessage = result[0];
-        });
-
-        test("recipient: create an incoming Request from the Message content", async () => {
+        test("recipient: sync the Message with the Request and create an incoming Request from the Message content", async () => {
             let triggeredEvent: IncomingRequestReceivedEvent | undefined;
             rEventBus.subscribeOnce(IncomingRequestReceivedEvent, (event) => {
                 triggeredEvent = event;
             });
 
+            rRequestMessage = await syncUntilHasMessageWithRequest(rTransportServices, sLocalRequest.id);
             const result = await rConsumptionServices.incomingRequests.received({
                 receivedRequest: rRequestMessage.content,
                 requestSourceId: rRequestMessage.id
@@ -281,20 +274,13 @@ describe("Requests", () => {
             expect(triggeredEvent!.data.newStatus).toBe(LocalRequestStatus.Completed);
         });
 
-        test("sender: sync Message with Response", async () => {
-            const result = await syncUntilHasMessages(sTransportServices);
-
-            expect(result).toHaveLength(1);
-
-            sResponseMessage = result[0];
-        });
-
-        test("sender: complete the outgoing Request with Response from Message", async () => {
+        test("sender: sync Message with Response and complete the outgoing Request with Response from Message", async () => {
             let triggeredEvent: OutgoingRequestStatusChangedEvent | undefined;
             sEventBus.subscribeOnce(OutgoingRequestStatusChangedEvent, (event) => {
                 triggeredEvent = event;
             });
 
+            sResponseMessage = await syncUntilHasMessageWithResponse(sTransportServices, sLocalRequest.id);
             const result = await sConsumptionServices.outgoingRequests.complete({
                 messageId: sResponseMessage.id,
                 receivedResponse: sResponseMessage.content

--- a/packages/runtime/test/dataViews/requestItems/ComplexReadAttributeRequestItemDVO.test.ts
+++ b/packages/runtime/test/dataViews/requestItems/ComplexReadAttributeRequestItemDVO.test.ts
@@ -16,7 +16,7 @@ import {
     RequestMessageDVO,
     TransportServices
 } from "../../../src";
-import { establishRelationship, MockEventBus, RuntimeServiceProvider, sendMessage, syncUntilHasMessages } from "../../lib";
+import { establishRelationship, MockEventBus, RuntimeServiceProvider, sendMessage, syncUntilHasMessages, syncUntilHasMessageWithRequest } from "../../lib";
 
 const serviceProvider = new RuntimeServiceProvider();
 let transportServices1: TransportServices;
@@ -79,12 +79,7 @@ describe("ComplexReadAttributeRequestItemDVO with IdentityAttributeQuery", () =>
         });
 
         senderMessage = await sendMessage(transportServices1, recipientAddress, localRequest.value.content);
-
-        const messages = await syncUntilHasMessages(transportServices2, 1);
-        if (messages.length < 1) {
-            throw new Error("Not enough messages synced");
-        }
-        recipientMessage = messages[0];
+        recipientMessage = await syncUntilHasMessageWithRequest(transportServices2, localRequest.value.id);
 
         await eventBus2.waitForEvent(IncomingRequestStatusChangedEvent, (e) => e.data.newStatus === LocalRequestStatus.DecisionRequired);
     }, 30000);
@@ -343,12 +338,7 @@ describe("ComplexReadAttributeRequestItemDVO with IQL", () => {
         });
 
         senderMessage = await sendMessage(transportServices1, recipientAddress, localRequest.value.content);
-
-        const messages = await syncUntilHasMessages(transportServices2, 1);
-        if (messages.length < 1) {
-            throw new Error("Not enough messages synced");
-        }
-        recipientMessage = messages[0];
+        recipientMessage = await syncUntilHasMessageWithRequest(transportServices2, localRequest.value.id);
 
         await eventBus2.waitForEvent(IncomingRequestStatusChangedEvent, (e) => e.data.newStatus === LocalRequestStatus.DecisionRequired);
     }, 30000);

--- a/packages/runtime/test/dataViews/requestItems/ComplexReadAttributeRequestItemDVO.test.ts
+++ b/packages/runtime/test/dataViews/requestItems/ComplexReadAttributeRequestItemDVO.test.ts
@@ -78,6 +78,7 @@ describe("ComplexReadAttributeRequestItemDVO with IdentityAttributeQuery", () =>
             },
             peer: recipientAddress
         });
+        requestId = localRequest.value.id;
 
         senderMessage = await sendMessage(transportServices1, recipientAddress, localRequest.value.content);
         recipientMessage = await syncUntilHasMessageWithRequest(transportServices2, localRequest.value.id);

--- a/packages/runtime/test/dataViews/requestItems/ComplexReadAttributeRequestItemDVO.test.ts
+++ b/packages/runtime/test/dataViews/requestItems/ComplexReadAttributeRequestItemDVO.test.ts
@@ -16,7 +16,7 @@ import {
     RequestMessageDVO,
     TransportServices
 } from "../../../src";
-import { establishRelationship, MockEventBus, RuntimeServiceProvider, sendMessage, syncUntilHasMessages, syncUntilHasMessageWithRequest } from "../../lib";
+import { establishRelationship, MockEventBus, RuntimeServiceProvider, sendMessage, syncUntilHasMessageWithRequest, syncUntilHasMessageWithResponse } from "../../lib";
 
 const serviceProvider = new RuntimeServiceProvider();
 let transportServices1: TransportServices;
@@ -29,6 +29,7 @@ let eventBus1: MockEventBus;
 let eventBus2: MockEventBus;
 let senderMessage: MessageDTO;
 let recipientMessage: MessageDTO;
+let requestId: string;
 
 afterAll(() => serviceProvider.stop());
 
@@ -232,7 +233,7 @@ describe("ComplexReadAttributeRequestItemDVO with IdentityAttributeQuery", () =>
     });
 
     test("check the MessageDVO for the sender after acceptance", async () => {
-        await syncUntilHasMessages(transportServices1, 1);
+        await syncUntilHasMessageWithResponse(transportServices1, requestId);
 
         await eventBus1.waitForEvent(OutgoingRequestStatusChangedEvent);
 
@@ -336,6 +337,7 @@ describe("ComplexReadAttributeRequestItemDVO with IQL", () => {
             },
             peer: recipientAddress
         });
+        requestId = localRequest.value.id;
 
         senderMessage = await sendMessage(transportServices1, recipientAddress, localRequest.value.content);
         recipientMessage = await syncUntilHasMessageWithRequest(transportServices2, localRequest.value.id);
@@ -476,7 +478,7 @@ describe("ComplexReadAttributeRequestItemDVO with IQL", () => {
     });
 
     test("check the MessageDVO for the sender after acceptance", async () => {
-        await syncUntilHasMessages(transportServices1, 1);
+        await syncUntilHasMessageWithResponse(transportServices1, requestId);
 
         await eventBus1.waitForEvent(OutgoingRequestStatusChangedEvent);
 

--- a/packages/runtime/test/dataViews/requestItems/CreateIdentityAttributeRequestItemDVO.test.ts
+++ b/packages/runtime/test/dataViews/requestItems/CreateIdentityAttributeRequestItemDVO.test.ts
@@ -12,7 +12,7 @@ import {
     RequestMessageDVO,
     TransportServices
 } from "../../../src";
-import { establishRelationship, MockEventBus, RuntimeServiceProvider, sendMessage, syncUntilHasMessages, syncUntilHasMessageWithRequest } from "../../lib";
+import { establishRelationship, MockEventBus, RuntimeServiceProvider, sendMessage, syncUntilHasMessageWithRequest, syncUntilHasMessageWithResponse } from "../../lib";
 
 const serviceProvider = new RuntimeServiceProvider();
 let sTransportServices: TransportServices;
@@ -25,6 +25,7 @@ let sEventBus: MockEventBus;
 let rEventBus: MockEventBus;
 let senderMessage: MessageDTO;
 let recipientMessage: MessageDTO;
+let requestId: string;
 
 beforeAll(async () => {
     const runtimeServices = await serviceProvider.launch(2, { enableRequestModule: true });
@@ -199,7 +200,7 @@ describe("CreateIdentityAttributeRequestItemDVO", () => {
     });
 
     test("check the MessageDVO for the sender after acceptance", async () => {
-        await syncUntilHasMessages(sTransportServices, 1);
+        await syncUntilHasMessageWithResponse(sTransportServices, requestId);
         await sEventBus.waitForEvent(OutgoingRequestStatusChangedEvent);
 
         const dto = senderMessage;

--- a/packages/runtime/test/dataViews/requestItems/CreateIdentityAttributeRequestItemDVO.test.ts
+++ b/packages/runtime/test/dataViews/requestItems/CreateIdentityAttributeRequestItemDVO.test.ts
@@ -12,7 +12,7 @@ import {
     RequestMessageDVO,
     TransportServices
 } from "../../../src";
-import { establishRelationship, MockEventBus, RuntimeServiceProvider, sendMessage, syncUntilHasMessages } from "../../lib";
+import { establishRelationship, MockEventBus, RuntimeServiceProvider, sendMessage, syncUntilHasMessages, syncUntilHasMessageWithRequest } from "../../lib";
 
 const serviceProvider = new RuntimeServiceProvider();
 let sTransportServices: TransportServices;
@@ -60,12 +60,7 @@ beforeAll(async () => {
     });
 
     senderMessage = await sendMessage(sTransportServices, rAddress, localRequest.value.content);
-
-    const messages = await syncUntilHasMessages(rTransportServices, 1);
-    if (messages.length < 1) {
-        throw new Error("Not enough messages synced");
-    }
-    recipientMessage = messages[0];
+    recipientMessage = await syncUntilHasMessageWithRequest(rTransportServices, localRequest.value.id);
 
     await rEventBus.waitForEvent(IncomingRequestStatusChangedEvent, (e) => e.data.newStatus === LocalRequestStatus.DecisionRequired);
 }, 30000);

--- a/packages/runtime/test/dataViews/requestItems/CreateIdentityAttributeRequestItemDVO.test.ts
+++ b/packages/runtime/test/dataViews/requestItems/CreateIdentityAttributeRequestItemDVO.test.ts
@@ -59,6 +59,7 @@ beforeAll(async () => {
         },
         peer: rAddress
     });
+    requestId = localRequest.value.id;
 
     senderMessage = await sendMessage(sTransportServices, rAddress, localRequest.value.content);
     recipientMessage = await syncUntilHasMessageWithRequest(rTransportServices, localRequest.value.id);

--- a/packages/runtime/test/dataViews/requestItems/CreateRelationshipAttributeRequestItemDVO.test.ts
+++ b/packages/runtime/test/dataViews/requestItems/CreateRelationshipAttributeRequestItemDVO.test.ts
@@ -12,7 +12,7 @@ import {
     RequestMessageDVO,
     TransportServices
 } from "../../../src";
-import { MockEventBus, RuntimeServiceProvider, establishRelationship, sendMessage, syncUntilHasMessages } from "../../lib";
+import { establishRelationship, MockEventBus, RuntimeServiceProvider, sendMessage, syncUntilHasMessages, syncUntilHasMessageWithRequest } from "../../lib";
 
 const serviceProvider = new RuntimeServiceProvider();
 let sTransportServices: TransportServices;
@@ -64,12 +64,7 @@ beforeAll(async () => {
     });
 
     senderMessage = await sendMessage(sTransportServices, rAddress, localRequest.value.content);
-
-    const messages = await syncUntilHasMessages(rTransportServices, 1);
-    if (messages.length < 1) {
-        throw new Error("Not enough messages synced");
-    }
-    recipientMessage = messages[0];
+    recipientMessage = await syncUntilHasMessageWithRequest(sTransportServices, localRequest.value.id);
 
     await rEventBus.waitForEvent(IncomingRequestStatusChangedEvent, (e) => e.data.newStatus === LocalRequestStatus.DecisionRequired);
 }, 30000);

--- a/packages/runtime/test/dataViews/requestItems/CreateRelationshipAttributeRequestItemDVO.test.ts
+++ b/packages/runtime/test/dataViews/requestItems/CreateRelationshipAttributeRequestItemDVO.test.ts
@@ -12,7 +12,7 @@ import {
     RequestMessageDVO,
     TransportServices
 } from "../../../src";
-import { establishRelationship, MockEventBus, RuntimeServiceProvider, sendMessage, syncUntilHasMessages, syncUntilHasMessageWithRequest } from "../../lib";
+import { establishRelationship, MockEventBus, RuntimeServiceProvider, sendMessage, syncUntilHasMessageWithRequest, syncUntilHasMessageWithResponse } from "../../lib";
 
 const serviceProvider = new RuntimeServiceProvider();
 let sTransportServices: TransportServices;
@@ -25,6 +25,7 @@ let sEventBus: MockEventBus;
 let rEventBus: MockEventBus;
 let senderMessage: MessageDTO;
 let recipientMessage: MessageDTO;
+let requestId: string;
 
 beforeAll(async () => {
     const runtimeServices = await serviceProvider.launch(2, { enableRequestModule: true });
@@ -204,7 +205,7 @@ describe("CreateRelationshipAttributeRequestItemDVO", () => {
     });
 
     test("check the MessageDVO for the sender after acceptance", async () => {
-        await syncUntilHasMessages(sTransportServices, 1);
+        await syncUntilHasMessageWithResponse(sTransportServices, requestId);
         await sEventBus.waitForEvent(OutgoingRequestStatusChangedEvent);
 
         const dto = senderMessage;

--- a/packages/runtime/test/dataViews/requestItems/CreateRelationshipAttributeRequestItemDVO.test.ts
+++ b/packages/runtime/test/dataViews/requestItems/CreateRelationshipAttributeRequestItemDVO.test.ts
@@ -63,9 +63,10 @@ beforeAll(async () => {
         },
         peer: rAddress
     });
+    requestId = localRequest.value.id;
 
     senderMessage = await sendMessage(sTransportServices, rAddress, localRequest.value.content);
-    recipientMessage = await syncUntilHasMessageWithRequest(sTransportServices, localRequest.value.id);
+    recipientMessage = await syncUntilHasMessageWithRequest(rTransportServices, localRequest.value.id);
 
     await rEventBus.waitForEvent(IncomingRequestStatusChangedEvent, (e) => e.data.newStatus === LocalRequestStatus.DecisionRequired);
 }, 30000);

--- a/packages/runtime/test/dataViews/requestItems/ProposeAttributeRequestItemDVO.test.ts
+++ b/packages/runtime/test/dataViews/requestItems/ProposeAttributeRequestItemDVO.test.ts
@@ -15,7 +15,7 @@ import {
     RequestMessageDVO,
     TransportServices
 } from "../../../src";
-import { establishRelationship, MockEventBus, RuntimeServiceProvider, sendMessage, syncUntilHasMessages, syncUntilHasMessageWithRequest } from "../../lib";
+import { establishRelationship, MockEventBus, RuntimeServiceProvider, sendMessage, syncUntilHasMessageWithRequest } from "../../lib";
 
 const serviceProvider = new RuntimeServiceProvider();
 let transportServices1: TransportServices;
@@ -28,6 +28,7 @@ let eventBus1: MockEventBus;
 let eventBus2: MockEventBus;
 let senderMessage: MessageDTO;
 let recipientMessage: MessageDTO;
+let requestId: string;
 
 beforeAll(async () => {
     const runtimeServices = await serviceProvider.launch(2, { enableRequestModule: true });
@@ -89,6 +90,7 @@ beforeAll(async () => {
         },
         peer: recipientAddress
     });
+    requestId = localRequest.value.id;
 
     senderMessage = await sendMessage(transportServices1, recipientAddress, localRequest.value.content);
     recipientMessage = await syncUntilHasMessageWithRequest(transportServices2, localRequest.value.id);
@@ -339,7 +341,7 @@ describe("ProposeAttributeRequestItemDVO", () => {
     });
 
     test("check the MessageDVO for the sender after acceptance", async () => {
-        await syncUntilHasMessages(transportServices1, 1);
+        await syncUntilHasMessageWithResponse(transportServices1, requestId);
 
         await eventBus1.waitForEvent(OutgoingRequestStatusChangedEvent);
 

--- a/packages/runtime/test/dataViews/requestItems/ProposeAttributeRequestItemDVO.test.ts
+++ b/packages/runtime/test/dataViews/requestItems/ProposeAttributeRequestItemDVO.test.ts
@@ -15,7 +15,7 @@ import {
     RequestMessageDVO,
     TransportServices
 } from "../../../src";
-import { establishRelationship, MockEventBus, RuntimeServiceProvider, sendMessage, syncUntilHasMessageWithRequest } from "../../lib";
+import { establishRelationship, MockEventBus, RuntimeServiceProvider, sendMessage, syncUntilHasMessageWithRequest, syncUntilHasMessageWithResponse } from "../../lib";
 
 const serviceProvider = new RuntimeServiceProvider();
 let transportServices1: TransportServices;

--- a/packages/runtime/test/dataViews/requestItems/ProposeAttributeRequestItemDVO.test.ts
+++ b/packages/runtime/test/dataViews/requestItems/ProposeAttributeRequestItemDVO.test.ts
@@ -15,7 +15,7 @@ import {
     RequestMessageDVO,
     TransportServices
 } from "../../../src";
-import { establishRelationship, MockEventBus, RuntimeServiceProvider, sendMessage, syncUntilHasMessages } from "../../lib";
+import { establishRelationship, MockEventBus, RuntimeServiceProvider, sendMessage, syncUntilHasMessages, syncUntilHasMessageWithRequest } from "../../lib";
 
 const serviceProvider = new RuntimeServiceProvider();
 let transportServices1: TransportServices;
@@ -91,10 +91,7 @@ beforeAll(async () => {
     });
 
     senderMessage = await sendMessage(transportServices1, recipientAddress, localRequest.value.content);
-
-    const messages = await syncUntilHasMessages(transportServices2, 1);
-
-    recipientMessage = messages[0];
+    recipientMessage = await syncUntilHasMessageWithRequest(transportServices2, localRequest.value.id);
 
     await eventBus2.waitForEvent(IncomingRequestStatusChangedEvent, (e) => e.data.newStatus === LocalRequestStatus.DecisionRequired);
 }, 30000);

--- a/packages/runtime/test/dataViews/requestItems/ReadAttributeRequestItemDVO.test.ts
+++ b/packages/runtime/test/dataViews/requestItems/ReadAttributeRequestItemDVO.test.ts
@@ -16,7 +16,7 @@ import {
     RequestMessageDVO,
     TransportServices
 } from "../../../src";
-import { establishRelationship, MockEventBus, RuntimeServiceProvider, sendMessage, syncUntilHasMessages } from "../../lib";
+import { establishRelationship, MockEventBus, RuntimeServiceProvider, sendMessage, syncUntilHasMessages, syncUntilHasMessageWithRequest } from "../../lib";
 
 const serviceProvider = new RuntimeServiceProvider();
 let transportServices1: TransportServices;
@@ -76,12 +76,7 @@ describe("ReadAttributeRequestItemDVO with IdentityAttributeQuery", () => {
         });
 
         senderMessage = await sendMessage(transportServices1, recipientAddress, localRequest.value.content);
-
-        const messages = await syncUntilHasMessages(transportServices2, 1);
-        if (messages.length < 1) {
-            throw new Error("Not enough messages synced");
-        }
-        recipientMessage = messages[0];
+        recipientMessage = await syncUntilHasMessageWithRequest(transportServices2, localRequest.value.id);
 
         await eventBus2.waitForEvent(IncomingRequestStatusChangedEvent, (e) => e.data.newStatus === LocalRequestStatus.DecisionRequired);
     }, 30000);
@@ -308,12 +303,7 @@ describe("ReadAttributeRequestItemDVO with IQL and results", () => {
         });
 
         senderMessage = await sendMessage(transportServices1, recipientAddress, localRequest.value.content);
-
-        const messages = await syncUntilHasMessages(transportServices2, 1);
-        if (messages.length < 1) {
-            throw new Error("Not enough messages synced");
-        }
-        recipientMessage = messages[0];
+        recipientMessage = await syncUntilHasMessageWithRequest(transportServices2, localRequest.value.id);
 
         await eventBus2.waitForEvent(IncomingRequestStatusChangedEvent, (e) => e.data.newStatus === LocalRequestStatus.DecisionRequired);
     }, 30000);
@@ -530,12 +520,7 @@ describe("ReadAttributeRequestItemDVO with IQL and fallback", () => {
         });
 
         senderMessage = await sendMessage(transportServices1, recipientAddress, localRequest.value.content);
-
-        const messages = await syncUntilHasMessages(transportServices2, 1);
-        if (messages.length < 1) {
-            throw new Error("Not enough messages synced");
-        }
-        recipientMessage = messages[0];
+        recipientMessage = await syncUntilHasMessageWithRequest(transportServices2, localRequest.value.id);
 
         await eventBus2.waitForEvent(IncomingRequestStatusChangedEvent, (e) => e.data.newStatus === LocalRequestStatus.DecisionRequired);
     }, 30000);

--- a/packages/runtime/test/dataViews/requestItems/ReadAttributeRequestItemDVO.test.ts
+++ b/packages/runtime/test/dataViews/requestItems/ReadAttributeRequestItemDVO.test.ts
@@ -16,7 +16,7 @@ import {
     RequestMessageDVO,
     TransportServices
 } from "../../../src";
-import { establishRelationship, MockEventBus, RuntimeServiceProvider, sendMessage, syncUntilHasMessages, syncUntilHasMessageWithRequest } from "../../lib";
+import { establishRelationship, MockEventBus, RuntimeServiceProvider, sendMessage, syncUntilHasMessageWithRequest, syncUntilHasMessageWithResponse } from "../../lib";
 
 const serviceProvider = new RuntimeServiceProvider();
 let transportServices1: TransportServices;
@@ -29,6 +29,7 @@ let eventBus1: MockEventBus;
 let eventBus2: MockEventBus;
 let senderMessage: MessageDTO;
 let recipientMessage: MessageDTO;
+let requestId: string;
 
 afterAll(() => serviceProvider.stop());
 
@@ -74,6 +75,7 @@ describe("ReadAttributeRequestItemDVO with IdentityAttributeQuery", () => {
             },
             peer: recipientAddress
         });
+        requestId = localRequest.value.id;
 
         senderMessage = await sendMessage(transportServices1, recipientAddress, localRequest.value.content);
         recipientMessage = await syncUntilHasMessageWithRequest(transportServices2, localRequest.value.id);
@@ -208,7 +210,7 @@ describe("ReadAttributeRequestItemDVO with IdentityAttributeQuery", () => {
     });
 
     test("check the MessageDVO for the sender after acceptance", async () => {
-        await syncUntilHasMessages(transportServices1, 1);
+        await syncUntilHasMessageWithResponse(transportServices1, requestId);
 
         await eventBus1.waitForEvent(OutgoingRequestStatusChangedEvent);
 
@@ -426,7 +428,7 @@ describe("ReadAttributeRequestItemDVO with IQL and results", () => {
     });
 
     test("check the MessageDVO for the sender after acceptance", async () => {
-        await syncUntilHasMessages(transportServices1, 1);
+        await syncUntilHasMessageWithResponse(transportServices1, requestId);
 
         await eventBus1.waitForEvent(OutgoingRequestStatusChangedEvent);
 
@@ -648,7 +650,7 @@ describe("ReadAttributeRequestItemDVO with IQL and fallback", () => {
     });
 
     test("check the MessageDVO for the sender after acceptance", async () => {
-        await syncUntilHasMessages(transportServices1, 1);
+        await syncUntilHasMessageWithResponse(transportServices1, requestId);
 
         await eventBus1.waitForEvent(OutgoingRequestStatusChangedEvent);
 

--- a/packages/runtime/test/dataViews/requestItems/ReadAttributeRequestItemDVO.test.ts
+++ b/packages/runtime/test/dataViews/requestItems/ReadAttributeRequestItemDVO.test.ts
@@ -303,6 +303,7 @@ describe("ReadAttributeRequestItemDVO with IQL and results", () => {
             },
             peer: recipientAddress
         });
+        requestId = localRequest.value.id;
 
         senderMessage = await sendMessage(transportServices1, recipientAddress, localRequest.value.content);
         recipientMessage = await syncUntilHasMessageWithRequest(transportServices2, localRequest.value.id);
@@ -520,6 +521,7 @@ describe("ReadAttributeRequestItemDVO with IQL and fallback", () => {
             },
             peer: recipientAddress
         });
+        requestId = localRequest.value.id;
 
         senderMessage = await sendMessage(transportServices1, recipientAddress, localRequest.value.content);
         recipientMessage = await syncUntilHasMessageWithRequest(transportServices2, localRequest.value.id);

--- a/packages/runtime/test/dataViews/requestItems/ShareAttributeRequestItemDVO.test.ts
+++ b/packages/runtime/test/dataViews/requestItems/ShareAttributeRequestItemDVO.test.ts
@@ -12,7 +12,7 @@ import {
     ShareAttributeRequestItemDVO,
     TransportServices
 } from "../../../src";
-import { establishRelationship, MockEventBus, RuntimeServiceProvider, sendMessage, syncUntilHasMessages } from "../../lib";
+import { establishRelationship, MockEventBus, RuntimeServiceProvider, sendMessage, syncUntilHasMessages, syncUntilHasMessageWithRequest } from "../../lib";
 
 const serviceProvider = new RuntimeServiceProvider();
 let sTransportServices: TransportServices;
@@ -63,12 +63,7 @@ beforeAll(async () => {
     });
 
     senderMessage = await sendMessage(sTransportServices, rAddress, localRequest.value.content);
-
-    const messages = await syncUntilHasMessages(rTransportServices, 1);
-    if (messages.length < 1) {
-        throw new Error("Not enough messages synced");
-    }
-    recipientMessage = messages[0];
+    recipientMessage = await syncUntilHasMessageWithRequest(rTransportServices, localRequest.value.id);
 
     await rEventBus.waitForEvent(IncomingRequestStatusChangedEvent, (e) => e.data.newStatus === LocalRequestStatus.DecisionRequired);
 }, 30000);

--- a/packages/runtime/test/dataViews/requestItems/ShareAttributeRequestItemDVO.test.ts
+++ b/packages/runtime/test/dataViews/requestItems/ShareAttributeRequestItemDVO.test.ts
@@ -12,7 +12,7 @@ import {
     ShareAttributeRequestItemDVO,
     TransportServices
 } from "../../../src";
-import { establishRelationship, MockEventBus, RuntimeServiceProvider, sendMessage, syncUntilHasMessages, syncUntilHasMessageWithRequest } from "../../lib";
+import { establishRelationship, MockEventBus, RuntimeServiceProvider, sendMessage, syncUntilHasMessageWithRequest, syncUntilHasMessageWithResponse } from "../../lib";
 
 const serviceProvider = new RuntimeServiceProvider();
 let sTransportServices: TransportServices;
@@ -25,6 +25,7 @@ let sEventBus: MockEventBus;
 let rEventBus: MockEventBus;
 let senderMessage: MessageDTO;
 let recipientMessage: MessageDTO;
+let requestId: string;
 
 beforeAll(async () => {
     const runtimeServices = await serviceProvider.launch(2, { enableRequestModule: true });
@@ -61,6 +62,7 @@ beforeAll(async () => {
         },
         peer: rAddress
     });
+    requestId = localRequest.value.id;
 
     senderMessage = await sendMessage(sTransportServices, rAddress, localRequest.value.content);
     recipientMessage = await syncUntilHasMessageWithRequest(rTransportServices, localRequest.value.id);
@@ -199,7 +201,7 @@ describe("ShareAttributeRequestItemDVO", () => {
     });
 
     test("check the MessageDVO for the sender after acceptance", async () => {
-        await syncUntilHasMessages(sTransportServices, 1);
+        await syncUntilHasMessageWithResponse(sTransportServices, requestId);
         await sEventBus.waitForEvent(OutgoingRequestStatusChangedEvent);
 
         const dto = senderMessage;

--- a/packages/runtime/test/lib/testUtils.ts
+++ b/packages/runtime/test/lib/testUtils.ts
@@ -87,7 +87,7 @@ export async function syncUntilHasMessageWithRequest(transportServices: Transpor
 
 export async function syncUntilHasMessageWithResponse(transportServices: TransportServices, requestId: string | CoreId): Promise<MessageDTO> {
     const filterResponseMessagesByRequestId = (syncResult: SyncEverythingResponse) => {
-        return syncResult.messages.filter((m) => (m.content["@type"] === "Response" || m.content["@type"] === "ResponseWrapper") && m.content.requestId === requestId.toString());
+        return syncResult.messages.filter((m) => m.content["@type"] === "ResponseWrapper" && m.content.requestId === requestId.toString());
     };
     const syncResult = await syncUntil(transportServices, (syncResult) => filterResponseMessagesByRequestId(syncResult).length !== 0);
     return filterResponseMessagesByRequestId(syncResult)[0];

--- a/packages/runtime/test/lib/testUtils.ts
+++ b/packages/runtime/test/lib/testUtils.ts
@@ -87,7 +87,7 @@ export async function syncUntilHasMessageWithRequest(transportServices: Transpor
 
 export async function syncUntilHasMessageWithResponse(transportServices: TransportServices, requestId: string | CoreId): Promise<MessageDTO> {
     const filterResponseMessagesByRequestId = (syncResult: SyncEverythingResponse) => {
-        return syncResult.messages.filter((m) => m.content["@type"] === "ResponseWrapper" && m.content.requestId === requestId.toString());
+        return syncResult.messages.filter((m) => (m.content["@type"] === "Response" || m.content["@type"] === "ResponseWrapper") && m.content.requestId === requestId.toString());
     };
     const syncResult = await syncUntil(transportServices, (syncResult) => filterResponseMessagesByRequestId(syncResult).length !== 0);
     return filterResponseMessagesByRequestId(syncResult)[0];

--- a/packages/runtime/test/modules/NotificationModule.test.ts
+++ b/packages/runtime/test/modules/NotificationModule.test.ts
@@ -2,7 +2,7 @@ import { ConsumptionIds, LocalNotificationStatus } from "@nmshd/consumption";
 import { Notification } from "@nmshd/content";
 import { CoreId } from "@nmshd/transport";
 import { ConsumptionServices, TransportServices } from "../../src";
-import { establishRelationship, MockEventBus, RuntimeServiceProvider, syncUntilHasMessages, TestNotificationItem, TestNotificationItemProcessor } from "../lib";
+import { establishRelationship, MockEventBus, RuntimeServiceProvider, syncUntilHasMessageWithNotification, TestNotificationItem, TestNotificationItemProcessor } from "../lib";
 
 const runtimeServiceProvider = new RuntimeServiceProvider();
 let sTransportServices: TransportServices;
@@ -53,7 +53,7 @@ describe("NotificationModule", () => {
     });
 
     test("runs received and process when receiving a Message containing a Notification", async () => {
-        await syncUntilHasMessages(rTransportServices);
+        await syncUntilHasMessageWithNotification(rTransportServices, notificationId);
         await rEventBus.waitForRunningEventHandlers();
 
         const getNotificationResult = await rConsumptionServices.notifications.getNotification({ id: notificationId.toString() });

--- a/packages/runtime/test/modules/RequestModule.test.ts
+++ b/packages/runtime/test/modules/RequestModule.test.ts
@@ -191,7 +191,6 @@ describe("RequestModule", () => {
             expect(requests).toHaveLength(1);
 
             const request = requests[0];
-            requestId = request.id;
 
             expect(request.content.items[0]["@type"]).toBe("CreateAttributeRequestItem");
         });
@@ -211,6 +210,7 @@ describe("RequestModule", () => {
 
             const requests = (await rConsumptionServices.incomingRequests.getRequests({ query: { "source.reference": template.id } })).value;
             const request = requests[0];
+            requestId = request.id;
 
             const requestAfterReject = (await rConsumptionServices.incomingRequests.reject({ requestId: request.id, items: [{ accept: false }] })).value;
 
@@ -238,6 +238,7 @@ describe("RequestModule", () => {
 
             const requests = (await rConsumptionServices.incomingRequests.getRequests({ query: { "source.reference": template.id } })).value;
             const request = requests[0];
+            requestId = request.id;
 
             const requestAfterReject = (await rConsumptionServices.incomingRequests.accept({ requestId: request.id, items: [{ accept: false }] })).value;
 
@@ -247,7 +248,7 @@ describe("RequestModule", () => {
         });
 
         test("receives the accepted Request by Message", async () => {
-            await syncUntilHasMessageWithRequest(rTransportServices, requestId);
+            await syncUntilHasMessageWithResponse(sTransportServices, requestId);
 
             await sEventBus.waitForRunningEventHandlers();
 

--- a/packages/runtime/test/modules/RequestModule.test.ts
+++ b/packages/runtime/test/modules/RequestModule.test.ts
@@ -23,7 +23,17 @@ import {
     RelationshipTemplateProcessedResult,
     TransportServices
 } from "../../src";
-import { ensureActiveRelationship, exchangeTemplate, MockEventBus, RuntimeServiceProvider, sendMessage, syncUntilHasMessages, syncUntilHasRelationships } from "../lib";
+import {
+    ensureActiveRelationship,
+    exchangeTemplate,
+    MockEventBus,
+    RuntimeServiceProvider,
+    sendMessage,
+    syncUntilHasMessages,
+    syncUntilHasMessageWithRequest,
+    syncUntilHasMessageWithResponse,
+    syncUntilHasRelationships
+} from "../lib";
 
 const runtimeServiceProvider = new RuntimeServiceProvider();
 let sTransportServices: TransportServices;
@@ -166,6 +176,8 @@ describe("RequestModule", () => {
     });
 
     describe("Relationships / RelationshipTemplates (onExistingRelationship)", () => {
+        let requestId: string;
+
         beforeAll(async () => await ensureActiveRelationship(sTransportServices, rTransportServices));
 
         test("creates a request from onExistingRelationship if a relationship already exists", async () => {
@@ -179,6 +191,7 @@ describe("RequestModule", () => {
             expect(requests).toHaveLength(1);
 
             const request = requests[0];
+            requestId = request.id;
 
             expect(request.content.items[0]["@type"]).toBe("CreateAttributeRequestItem");
         });
@@ -207,11 +220,9 @@ describe("RequestModule", () => {
         });
 
         test("receives the rejected Request by Message", async () => {
-            const message = (await syncUntilHasMessages(sTransportServices, 1))[0];
+            await syncUntilHasMessageWithResponse(sTransportServices, requestId);
 
             await sEventBus.waitForRunningEventHandlers();
-
-            const requestId = message.content.requestId;
 
             await expect(sEventBus).toHavePublished(OutgoingRequestCreatedAndCompletedEvent, (e) => e.data.id === requestId);
 
@@ -236,11 +247,9 @@ describe("RequestModule", () => {
         });
 
         test("receives the accepted Request by Message", async () => {
-            const message = (await syncUntilHasMessages(sTransportServices, 1))[0];
+            await syncUntilHasMessageWithRequest(rTransportServices, requestId);
 
             await sEventBus.waitForRunningEventHandlers();
-
-            const requestId = message.content.requestId;
 
             await expect(sEventBus).toHavePublished(OutgoingRequestCreatedAndCompletedEvent, (e) => e.data.id === requestId);
 
@@ -303,8 +312,7 @@ describe("RequestModule", () => {
         });
 
         test("the incoming request is created and moved to status DecisionRequired", async () => {
-            const messages = await syncUntilHasMessages(rTransportServices, 1);
-            expect(messages).toHaveLength(1);
+            await syncUntilHasMessageWithRequest(rTransportServices, requestId);
 
             const incomingRequestReceivedEvent = await rEventBus.waitForEvent(IncomingRequestReceivedEvent);
             const request = incomingRequestReceivedEvent.data;
@@ -341,8 +349,7 @@ describe("RequestModule", () => {
         });
 
         test("processes the response", async () => {
-            const messages = await syncUntilHasMessages(sTransportServices, 1);
-            expect(messages).toHaveLength(1);
+            await syncUntilHasMessageWithResponse(sTransportServices, requestId);
 
             const outgoingRequestStatusChangedEvent = await sEventBus.waitForEvent(OutgoingRequestStatusChangedEvent, (e) => e.data.newStatus === LocalRequestStatus.Completed);
             expect(outgoingRequestStatusChangedEvent.data.newStatus).toBe(LocalRequestStatus.Completed);


### PR DESCRIPTION
no work on the tests attribute.test.ts and attribute-e2e.test.ts because Milena is doing them

(Presumably) a race condition for the syncUntil-function causes tests to occasionally fail.