### PR TITLE
Chore/check instance on wait for event

### DIFF
--- a/packages/runtime/test/lib/MockEventBus.ts
+++ b/packages/runtime/test/lib/MockEventBus.ts
@@ -25,13 +25,12 @@ export class MockEventBus extends EventEmitter2EventBus {
         subscriptionTarget: SubscriptionTarget<TEvent> & { namespace: string },
         predicate?: (event: TEvent) => boolean
     ): Promise<TEvent> {
-        const alreadyTriggeredEvents = this.publishedEvents.find((e) => {
-            return (
+        const alreadyTriggeredEvents = this.publishedEvents.find(
+            (e) =>
                 e.namespace === subscriptionTarget.namespace &&
-                (typeof subscriptionTarget === "string" || e instanceof (subscriptionTarget as any)) &&
+                (typeof subscriptionTarget === "string" || e instanceof subscriptionTarget) &&
                 (!predicate || predicate(e as TEvent))
-            );
-        }) as TEvent | undefined;
+        ) as TEvent | undefined;
         if (alreadyTriggeredEvents) {
             return alreadyTriggeredEvents;
         }

--- a/packages/runtime/test/lib/MockEventBus.ts
+++ b/packages/runtime/test/lib/MockEventBus.ts
@@ -26,7 +26,11 @@ export class MockEventBus extends EventEmitter2EventBus {
         predicate?: (event: TEvent) => boolean
     ): Promise<TEvent> {
         const alreadyTriggeredEvents = this.publishedEvents.find((e) => {
-            return e.namespace === subscriptionTarget.namespace && e instanceof (subscriptionTarget as any) && (!predicate || predicate(e as TEvent));
+            return (
+                e.namespace === subscriptionTarget.namespace &&
+                (typeof subscriptionTarget === "string" || e instanceof (subscriptionTarget as any)) &&
+                (!predicate || predicate(e as TEvent))
+            );
         }) as TEvent | undefined;
         if (alreadyTriggeredEvents) {
             return alreadyTriggeredEvents;

--- a/packages/runtime/test/lib/MockEventBus.ts
+++ b/packages/runtime/test/lib/MockEventBus.ts
@@ -26,8 +26,7 @@ export class MockEventBus extends EventEmitter2EventBus {
         predicate?: (event: TEvent) => boolean
     ): Promise<TEvent> {
         const alreadyTriggeredEvents = this.publishedEvents.find((e) => {
-            const i = e instanceof (subscriptionTarget as any);
-            return e.namespace === subscriptionTarget.namespace && i && (!predicate || predicate(e as TEvent));
+            return e.namespace === subscriptionTarget.namespace && e instanceof (subscriptionTarget as any) && (!predicate || predicate(e as TEvent));
         }) as TEvent | undefined;
         if (alreadyTriggeredEvents) {
             return alreadyTriggeredEvents;

--- a/packages/runtime/test/lib/MockEventBus.ts
+++ b/packages/runtime/test/lib/MockEventBus.ts
@@ -25,9 +25,10 @@ export class MockEventBus extends EventEmitter2EventBus {
         subscriptionTarget: SubscriptionTarget<TEvent> & { namespace: string },
         predicate?: (event: TEvent) => boolean
     ): Promise<TEvent> {
-        const alreadyTriggeredEvents = this.publishedEvents.find((e) => e.namespace === subscriptionTarget.namespace && (!predicate || predicate(e as TEvent))) as
-            | TEvent
-            | undefined;
+        const alreadyTriggeredEvents = this.publishedEvents.find((e) => {
+            const i = e instanceof (subscriptionTarget as any);
+            return e.namespace === subscriptionTarget.namespace && i && (!predicate || predicate(e as TEvent));
+        }) as TEvent | undefined;
         if (alreadyTriggeredEvents) {
             return alreadyTriggeredEvents;
         }


### PR DESCRIPTION
The mock event bus is checking for the instance of the event constructor when given this is not done by the pre-check for already fired events so using a consumption event instance in the runtime will work as long as it is already fired before the waitFor.