### PR TITLE
Fix/ditch easy-tsnameof

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4779,13 +4779,6 @@
             "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
             "dev": true
         },
-        "node_modules/easy-tsnameof": {
-            "version": "3.0.6",
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            }
-        },
         "node_modules/ee-first": {
             "version": "1.1.1",
             "dev": true,
@@ -12476,7 +12469,8 @@
         },
         "node_modules/ts-simple-nameof": {
             "version": "1.3.1",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/ts-simple-nameof/-/ts-simple-nameof-1.3.1.tgz",
+            "integrity": "sha512-E0xwaLwDmKmSmo4DE4i+Rp0CuixeZ6wJcn4+2OugzSoPxWW27aNRHhfhcfAELavHHS077dt998oXIMFq+MqeBw=="
         },
         "node_modules/tsconfig-paths": {
             "version": "4.2.0",
@@ -13475,7 +13469,7 @@
             "dependencies": {
                 "@js-soft/logging-abstractions": "^1.0.1",
                 "@nmshd/iql": "^1.0.2",
-                "easy-tsnameof": "^3.0.6"
+                "ts-simple-nameof": "^1.3.1"
             },
             "devDependencies": {
                 "@js-soft/ts-serval": "2.0.10",

--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -53,6 +53,7 @@
     "dependencies": {
         "@js-soft/logging-abstractions": "^1.0.1",
         "@nmshd/iql": "^1.0.2",
+        "ts-simple-nameof": "^1.3.1",
         "easy-tsnameof": "^3.0.6"
     },
     "devDependencies": {

--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -53,8 +53,7 @@
     "dependencies": {
         "@js-soft/logging-abstractions": "^1.0.1",
         "@nmshd/iql": "^1.0.2",
-        "ts-simple-nameof": "^1.3.1",
-        "easy-tsnameof": "^3.0.6"
+        "ts-simple-nameof": "^1.3.1"
     },
     "devDependencies": {
         "@js-soft/ts-serval": "2.0.10",

--- a/packages/content/src/attributes/types/address/AbstractAddress.ts
+++ b/packages/content/src/attributes/types/address/AbstractAddress.ts
@@ -1,5 +1,5 @@
 import { serialize, validate } from "@js-soft/ts-serval";
-import nameOf from "easy-tsnameof";
+import { nameof } from "ts-simple-nameof";
 import { AbstractComplexValue, AbstractComplexValueJSON, IAbstractComplexValue } from "../../AbstractComplexValue";
 import { RenderHints, RenderHintsEditType, RenderHintsTechnicalType, ValueHints } from "../../hints";
 
@@ -12,8 +12,6 @@ export interface IAbstractAddress extends IAbstractComplexValue {
 }
 
 export abstract class AbstractAddress extends AbstractComplexValue implements IAbstractAddress {
-    public static readonly propertyNames = nameOf<AbstractAddress, never>();
-
     @serialize()
     @validate({ max: 100 })
     public recipient: string;
@@ -21,7 +19,7 @@ export abstract class AbstractAddress extends AbstractComplexValue implements IA
     public static get valueHints(): ValueHints {
         return ValueHints.from({
             propertyHints: {
-                [this.propertyNames.recipient.$path]: ValueHints.from({})
+                [nameof<AbstractAddress>((a) => a.recipient)]: ValueHints.from({})
             }
         });
     }
@@ -29,7 +27,7 @@ export abstract class AbstractAddress extends AbstractComplexValue implements IA
     public static override get renderHints(): RenderHints {
         return super.renderHints.copyWith({
             propertyHints: {
-                [this.propertyNames.recipient.$path]: RenderHints.from({
+                [nameof<AbstractAddress>((a) => a.recipient)]: RenderHints.from({
                     editType: RenderHintsEditType.InputLike,
                     technicalType: RenderHintsTechnicalType.String
                 })

--- a/packages/content/src/attributes/types/address/DeliveryBoxAddress.ts
+++ b/packages/content/src/attributes/types/address/DeliveryBoxAddress.ts
@@ -1,5 +1,5 @@
 import { serialize, type, validate } from "@js-soft/ts-serval";
-import nameOf from "easy-tsnameof";
+import { nameof } from "ts-simple-nameof";
 import { AbstractAttributeValue } from "../../AbstractAttributeValue";
 import { COUNTRIES_ALPHA2_TO_ENGLISH_NAME } from "../../constants";
 import { RenderHints, RenderHintsEditType, RenderHintsTechnicalType, ValueHints } from "../../hints";
@@ -33,8 +33,6 @@ export interface IDeliveryBoxAddress extends IAbstractAddress {
 
 @type("DeliveryBoxAddress")
 export class DeliveryBoxAddress extends AbstractAddress implements IDeliveryBoxAddress {
-    public static override readonly propertyNames = nameOf<DeliveryBoxAddress, never>();
-
     @serialize()
     @validate({ max: 100 })
     public userId: string;
@@ -66,13 +64,13 @@ export class DeliveryBoxAddress extends AbstractAddress implements IDeliveryBoxA
     public static override get valueHints(): ValueHints {
         return super.valueHints.copyWith({
             propertyHints: {
-                [this.propertyNames.userId.$path]: ValueHints.from({}),
-                [this.propertyNames.deliveryBoxId.$path]: ValueHints.from({}),
-                [this.propertyNames.zipCode.$path]: ZipCode.valueHints,
-                [this.propertyNames.city.$path]: City.valueHints,
-                [this.propertyNames.country.$path]: Country.valueHints,
-                [this.propertyNames.phoneNumber.$path]: PhoneNumber.valueHints,
-                [this.propertyNames.state.$path]: State.valueHints
+                [nameof<DeliveryBoxAddress>((d) => d.userId)]: ValueHints.from({}),
+                [nameof<DeliveryBoxAddress>((d) => d.deliveryBoxId)]: ValueHints.from({}),
+                [nameof<DeliveryBoxAddress>((d) => d.zipCode)]: ZipCode.valueHints,
+                [nameof<DeliveryBoxAddress>((d) => d.city)]: City.valueHints,
+                [nameof<DeliveryBoxAddress>((d) => d.country)]: Country.valueHints,
+                [nameof<DeliveryBoxAddress>((d) => d.phoneNumber)]: PhoneNumber.valueHints,
+                [nameof<DeliveryBoxAddress>((d) => d.state)]: State.valueHints
             }
         });
     }
@@ -80,19 +78,19 @@ export class DeliveryBoxAddress extends AbstractAddress implements IDeliveryBoxA
     public static override get renderHints(): RenderHints {
         return super.renderHints.copyWith({
             propertyHints: {
-                [this.propertyNames.userId.$path]: RenderHints.from({
+                [nameof<DeliveryBoxAddress>((d) => d.userId)]: RenderHints.from({
                     editType: RenderHintsEditType.InputLike,
                     technicalType: RenderHintsTechnicalType.String
                 }),
-                [this.propertyNames.deliveryBoxId.$path]: RenderHints.from({
+                [nameof<DeliveryBoxAddress>((d) => d.deliveryBoxId)]: RenderHints.from({
                     editType: RenderHintsEditType.InputLike,
                     technicalType: RenderHintsTechnicalType.String
                 }),
-                [this.propertyNames.zipCode.$path]: ZipCode.renderHints,
-                [this.propertyNames.city.$path]: City.renderHints,
-                [this.propertyNames.country.$path]: Country.renderHints,
-                [this.propertyNames.phoneNumber.$path]: PhoneNumber.renderHints,
-                [this.propertyNames.state.$path]: State.renderHints
+                [nameof<DeliveryBoxAddress>((d) => d.zipCode)]: ZipCode.renderHints,
+                [nameof<DeliveryBoxAddress>((d) => d.city)]: City.renderHints,
+                [nameof<DeliveryBoxAddress>((d) => d.country)]: Country.renderHints,
+                [nameof<DeliveryBoxAddress>((d) => d.phoneNumber)]: PhoneNumber.renderHints,
+                [nameof<DeliveryBoxAddress>((d) => d.state)]: State.renderHints
             }
         });
     }

--- a/packages/content/src/attributes/types/address/PostOfficeBoxAddress.ts
+++ b/packages/content/src/attributes/types/address/PostOfficeBoxAddress.ts
@@ -1,5 +1,5 @@
 import { serialize, type, validate } from "@js-soft/ts-serval";
-import nameOf from "easy-tsnameof";
+import { nameof } from "ts-simple-nameof";
 import { AbstractAttributeValue } from "../../AbstractAttributeValue";
 import { COUNTRIES_ALPHA2_TO_ENGLISH_NAME } from "../../constants";
 import { RenderHints, RenderHintsEditType, RenderHintsTechnicalType, ValueHints } from "../../hints";
@@ -28,8 +28,6 @@ export interface IPostOfficeBoxAddress extends IAbstractAddress {
 
 @type("PostOfficeBoxAddress")
 export class PostOfficeBoxAddress extends AbstractAddress implements IPostOfficeBoxAddress {
-    public static override readonly propertyNames = nameOf<PostOfficeBoxAddress, never>();
-
     @serialize()
     @validate({ max: 100 })
     public boxId: string;
@@ -53,11 +51,11 @@ export class PostOfficeBoxAddress extends AbstractAddress implements IPostOffice
     public static override get valueHints(): ValueHints {
         return super.valueHints.copyWith({
             propertyHints: {
-                [this.propertyNames.boxId.$path]: ValueHints.from({}),
-                [this.propertyNames.zipCode.$path]: ZipCode.valueHints,
-                [this.propertyNames.city.$path]: City.valueHints,
-                [this.propertyNames.country.$path]: Country.valueHints,
-                [this.propertyNames.state.$path]: State.valueHints
+                [nameof<PostOfficeBoxAddress>((p) => p.boxId)]: ValueHints.from({}),
+                [nameof<PostOfficeBoxAddress>((p) => p.zipCode)]: ZipCode.valueHints,
+                [nameof<PostOfficeBoxAddress>((p) => p.city)]: City.valueHints,
+                [nameof<PostOfficeBoxAddress>((p) => p.country)]: Country.valueHints,
+                [nameof<PostOfficeBoxAddress>((p) => p.state)]: State.valueHints
             }
         });
     }
@@ -65,14 +63,14 @@ export class PostOfficeBoxAddress extends AbstractAddress implements IPostOffice
     public static override get renderHints(): RenderHints {
         return super.renderHints.copyWith({
             propertyHints: {
-                [this.propertyNames.boxId.$path]: RenderHints.from({
+                [nameof<PostOfficeBoxAddress>((p) => p.boxId)]: RenderHints.from({
                     editType: RenderHintsEditType.InputLike,
                     technicalType: RenderHintsTechnicalType.String
                 }),
-                [this.propertyNames.zipCode.$path]: ZipCode.renderHints,
-                [this.propertyNames.city.$path]: City.renderHints,
-                [this.propertyNames.country.$path]: Country.renderHints,
-                [this.propertyNames.state.$path]: State.renderHints
+                [nameof<PostOfficeBoxAddress>((p) => p.zipCode)]: ZipCode.renderHints,
+                [nameof<PostOfficeBoxAddress>((p) => p.city)]: City.renderHints,
+                [nameof<PostOfficeBoxAddress>((p) => p.country)]: Country.renderHints,
+                [nameof<PostOfficeBoxAddress>((p) => p.state)]: State.renderHints
             }
         });
     }

--- a/packages/content/src/attributes/types/address/StreetAddress.ts
+++ b/packages/content/src/attributes/types/address/StreetAddress.ts
@@ -1,5 +1,5 @@
 import { serialize, type, validate } from "@js-soft/ts-serval";
-import { nameOf as nameof } from "easy-tsnameof";
+import { nameof } from "ts-simple-nameof";
 import { AbstractAttributeValue } from "../../AbstractAttributeValue";
 import { COUNTRIES_ALPHA2_TO_ENGLISH_NAME } from "../../constants";
 import { RenderHints, ValueHints } from "../../hints";
@@ -32,8 +32,6 @@ export interface IStreetAddress extends IAbstractAddress {
 
 @type("StreetAddress")
 export class StreetAddress extends AbstractAddress implements IStreetAddress {
-    public static override readonly propertyNames = nameof<StreetAddress, never>();
-
     @serialize({ customGenerator: AbstractAttributeValue.valueGenerator })
     @validate()
     public street: Street;
@@ -65,12 +63,12 @@ export class StreetAddress extends AbstractAddress implements IStreetAddress {
     public static override get valueHints(): ValueHints {
         return super.valueHints.copyWith({
             propertyHints: {
-                [this.propertyNames.street.$path]: Street.valueHints,
-                [this.propertyNames.houseNo.$path]: HouseNumber.valueHints,
-                [this.propertyNames.zipCode.$path]: ZipCode.valueHints,
-                [this.propertyNames.city.$path]: City.valueHints,
-                [this.propertyNames.country.$path]: Country.valueHints,
-                [this.propertyNames.state.$path]: State.valueHints
+                [nameof<StreetAddress>((s) => s.street)]: Street.valueHints,
+                [nameof<StreetAddress>((s) => s.houseNo)]: HouseNumber.valueHints,
+                [nameof<StreetAddress>((s) => s.zipCode)]: ZipCode.valueHints,
+                [nameof<StreetAddress>((s) => s.city)]: City.valueHints,
+                [nameof<StreetAddress>((s) => s.country)]: Country.valueHints,
+                [nameof<StreetAddress>((s) => s.state)]: State.valueHints
             }
         });
     }
@@ -78,12 +76,12 @@ export class StreetAddress extends AbstractAddress implements IStreetAddress {
     public static override get renderHints(): RenderHints {
         return super.renderHints.copyWith({
             propertyHints: {
-                [this.propertyNames.street.$path]: Street.renderHints,
-                [this.propertyNames.houseNo.$path]: HouseNumber.renderHints,
-                [this.propertyNames.zipCode.$path]: ZipCode.renderHints,
-                [this.propertyNames.city.$path]: City.renderHints,
-                [this.propertyNames.country.$path]: Country.renderHints,
-                [this.propertyNames.state.$path]: State.renderHints
+                [nameof<StreetAddress>((s) => s.street)]: Street.renderHints,
+                [nameof<StreetAddress>((s) => s.houseNo)]: HouseNumber.renderHints,
+                [nameof<StreetAddress>((s) => s.zipCode)]: ZipCode.renderHints,
+                [nameof<StreetAddress>((s) => s.city)]: City.renderHints,
+                [nameof<StreetAddress>((s) => s.country)]: Country.renderHints,
+                [nameof<StreetAddress>((s) => s.state)]: State.renderHints
             }
         });
     }

--- a/packages/content/src/attributes/types/affiliation/Affiliation.ts
+++ b/packages/content/src/attributes/types/affiliation/Affiliation.ts
@@ -1,5 +1,5 @@
 import { serialize, type, validate } from "@js-soft/ts-serval";
-import nameOf from "easy-tsnameof";
+import { nameof } from "ts-simple-nameof";
 import { AbstractAttributeValue } from "../../AbstractAttributeValue";
 import { AbstractComplexValue, AbstractComplexValueJSON, IAbstractComplexValue } from "../../AbstractComplexValue";
 import { RenderHints, ValueHints } from "../../hints";
@@ -22,8 +22,6 @@ export interface IAffiliation extends IAbstractComplexValue {
 
 @type("Affiliation")
 export class Affiliation extends AbstractComplexValue implements IAffiliation {
-    public static readonly propertyNames = nameOf<Affiliation, never>();
-
     @serialize({ customGenerator: AbstractAttributeValue.valueGenerator })
     @validate({ nullable: true })
     public role?: AffiliationRole;
@@ -39,9 +37,9 @@ export class Affiliation extends AbstractComplexValue implements IAffiliation {
     public static get valueHints(): ValueHints {
         return ValueHints.from({
             propertyHints: {
-                [this.propertyNames.role.$path]: AffiliationRole.valueHints,
-                [this.propertyNames.organization.$path]: AffiliationOrganization.valueHints,
-                [this.propertyNames.unit.$path]: AffiliationUnit.valueHints
+                [nameof<Affiliation>((a) => a.role)]: AffiliationRole.valueHints,
+                [nameof<Affiliation>((a) => a.organization)]: AffiliationOrganization.valueHints,
+                [nameof<Affiliation>((a) => a.unit)]: AffiliationUnit.valueHints
             }
         });
     }
@@ -49,9 +47,9 @@ export class Affiliation extends AbstractComplexValue implements IAffiliation {
     public static override get renderHints(): RenderHints {
         return super.renderHints.copyWith({
             propertyHints: {
-                [this.propertyNames.role.$path]: AffiliationRole.renderHints,
-                [this.propertyNames.organization.$path]: AffiliationOrganization.renderHints,
-                [this.propertyNames.unit.$path]: AffiliationUnit.renderHints
+                [nameof<Affiliation>((a) => a.role)]: AffiliationRole.renderHints,
+                [nameof<Affiliation>((a) => a.organization)]: AffiliationOrganization.renderHints,
+                [nameof<Affiliation>((a) => a.unit)]: AffiliationUnit.renderHints
             }
         });
     }

--- a/packages/content/src/attributes/types/birth/BirthDate.ts
+++ b/packages/content/src/attributes/types/birth/BirthDate.ts
@@ -1,6 +1,6 @@
 import { Serializable, serialize, type, validate } from "@js-soft/ts-serval";
-import nameOf from "easy-tsnameof";
 import { DateTime } from "luxon";
+import { nameof } from "ts-simple-nameof";
 import { ValidationErrorWithoutProperty } from "../../../ValidationErrorWithoutProperty";
 import { AbstractAttributeValue } from "../../AbstractAttributeValue";
 import { AbstractComplexValue, AbstractComplexValueJSON, IAbstractComplexValue } from "../../AbstractComplexValue";
@@ -24,8 +24,6 @@ export interface IBirthDate extends IAbstractComplexValue {
 
 @type("BirthDate")
 export class BirthDate extends AbstractComplexValue implements IBirthDate {
-    public static readonly propertyNames = nameOf<BirthDate, never>();
-
     @serialize({ customGenerator: AbstractAttributeValue.valueGenerator })
     @validate()
     public day: BirthDay;
@@ -58,9 +56,9 @@ export class BirthDate extends AbstractComplexValue implements IBirthDate {
     public static get valueHints(): ValueHints {
         return ValueHints.from({
             propertyHints: {
-                [this.propertyNames.day.$path]: BirthDay.valueHints,
-                [this.propertyNames.month.$path]: BirthMonth.valueHints,
-                [this.propertyNames.year.$path]: BirthYear.valueHints
+                [nameof<BirthDate>((b) => b.day)]: BirthDay.valueHints,
+                [nameof<BirthDate>((b) => b.month)]: BirthMonth.valueHints,
+                [nameof<BirthDate>((b) => b.year)]: BirthYear.valueHints
             }
         });
     }
@@ -68,9 +66,9 @@ export class BirthDate extends AbstractComplexValue implements IBirthDate {
     public static override get renderHints(): RenderHints {
         return super.renderHints.copyWith({
             propertyHints: {
-                [this.propertyNames.day.$path]: BirthDay.renderHints,
-                [this.propertyNames.month.$path]: BirthMonth.renderHints,
-                [this.propertyNames.year.$path]: BirthYear.renderHints
+                [nameof<BirthDate>((b) => b.day)]: BirthDay.renderHints,
+                [nameof<BirthDate>((b) => b.month)]: BirthMonth.renderHints,
+                [nameof<BirthDate>((b) => b.year)]: BirthYear.renderHints
             }
         });
     }

--- a/packages/content/src/attributes/types/birth/BirthPlace.ts
+++ b/packages/content/src/attributes/types/birth/BirthPlace.ts
@@ -1,5 +1,5 @@
 import { serialize, type, validate } from "@js-soft/ts-serval";
-import nameOf from "easy-tsnameof";
+import { nameof } from "ts-simple-nameof";
 import { AbstractAttributeValue } from "../../AbstractAttributeValue";
 import { AbstractComplexValue, AbstractComplexValueJSON, IAbstractComplexValue } from "../../AbstractComplexValue";
 import { RenderHints, ValueHints } from "../../hints";
@@ -22,8 +22,6 @@ export interface IBirthPlace extends IAbstractComplexValue {
 
 @type("BirthPlace")
 export class BirthPlace extends AbstractComplexValue implements IBirthPlace {
-    public static readonly propertyNames = nameOf<BirthPlace, never>();
-
     @serialize({ customGenerator: AbstractAttributeValue.valueGenerator })
     @validate()
     public city: BirthCity;
@@ -39,9 +37,9 @@ export class BirthPlace extends AbstractComplexValue implements IBirthPlace {
     public static get valueHints(): ValueHints {
         return ValueHints.from({
             propertyHints: {
-                [this.propertyNames.city.$path]: BirthCity.valueHints,
-                [this.propertyNames.country.$path]: BirthCountry.valueHints,
-                [this.propertyNames.state.$path]: BirthState.valueHints
+                [nameof<BirthPlace>((b) => b.city)]: BirthCity.valueHints,
+                [nameof<BirthPlace>((b) => b.country)]: BirthCountry.valueHints,
+                [nameof<BirthPlace>((b) => b.state)]: BirthState.valueHints
             }
         });
     }
@@ -49,9 +47,9 @@ export class BirthPlace extends AbstractComplexValue implements IBirthPlace {
     public static override get renderHints(): RenderHints {
         return super.renderHints.copyWith({
             propertyHints: {
-                [this.propertyNames.city.$path]: BirthCity.renderHints,
-                [this.propertyNames.country.$path]: BirthCountry.renderHints,
-                [this.propertyNames.state.$path]: BirthState.renderHints
+                [nameof<BirthPlace>((b) => b.city)]: BirthCity.renderHints,
+                [nameof<BirthPlace>((b) => b.country)]: BirthCountry.renderHints,
+                [nameof<BirthPlace>((b) => b.state)]: BirthState.renderHints
             }
         });
     }

--- a/packages/content/src/attributes/types/measurements/AbstractLengthMeasurement.ts
+++ b/packages/content/src/attributes/types/measurements/AbstractLengthMeasurement.ts
@@ -1,4 +1,5 @@
 import { serialize, validate } from "@js-soft/ts-serval";
+import { nameof } from "ts-simple-nameof";
 import { ValueHints, ValueHintsValue } from "../../hints";
 import { AbstractMeasurement } from "./AbstractMeasurement";
 
@@ -27,7 +28,7 @@ export class AbstractLengthMeasurement extends AbstractMeasurement {
     public static override get valueHints(): ValueHints {
         return super.valueHints.copyWith({
             propertyHints: {
-                [this.propertyNames.unit.$path]: ValueHints.from({
+                [nameof<AbstractLengthMeasurement>((a) => a.unit)]: ValueHints.from({
                     values: Object.entries(LengthUnit).map((v) =>
                         ValueHintsValue.from({
                             displayName: v[1],

--- a/packages/content/src/attributes/types/measurements/AbstractMeasurement.ts
+++ b/packages/content/src/attributes/types/measurements/AbstractMeasurement.ts
@@ -1,5 +1,5 @@
 import { serialize, validate } from "@js-soft/ts-serval";
-import nameOf from "easy-tsnameof";
+import { nameof } from "ts-simple-nameof";
 import { AbstractComplexValue, AbstractComplexValueJSON, IAbstractComplexValue } from "../../AbstractComplexValue";
 import { RenderHints, RenderHintsEditType, RenderHintsTechnicalType, ValueHints } from "../../hints";
 
@@ -17,8 +17,6 @@ export interface IMeasurement extends IAbstractComplexValue {
  * valid unit strings must be defined in the classes extending AbstractMeasurement as enum
  */
 export abstract class AbstractMeasurement extends AbstractComplexValue implements IMeasurement {
-    public static readonly propertyNames = nameOf<AbstractMeasurement, never>();
-
     @serialize()
     @validate({ max: 50 })
     public unit: string;
@@ -30,8 +28,8 @@ export abstract class AbstractMeasurement extends AbstractComplexValue implement
     public static get valueHints(): ValueHints {
         return ValueHints.from({
             propertyHints: {
-                [this.propertyNames.unit.$path]: ValueHints.from({}),
-                [this.propertyNames.value.$path]: ValueHints.from({})
+                [nameof<AbstractMeasurement>((a) => a.unit)]: ValueHints.from({}),
+                [nameof<AbstractMeasurement>((a) => a.value)]: ValueHints.from({})
             }
         });
     }
@@ -39,11 +37,11 @@ export abstract class AbstractMeasurement extends AbstractComplexValue implement
     public static override get renderHints(): RenderHints {
         return super.renderHints.copyWith({
             propertyHints: {
-                [this.propertyNames.unit.$path]: RenderHints.from({
+                [nameof<AbstractMeasurement>((a) => a.unit)]: RenderHints.from({
                     editType: RenderHintsEditType.InputLike,
                     technicalType: RenderHintsTechnicalType.String
                 }),
-                [this.propertyNames.value.$path]: RenderHints.from({
+                [nameof<AbstractMeasurement>((a) => a.value)]: RenderHints.from({
                     editType: RenderHintsEditType.InputLike,
                     technicalType: RenderHintsTechnicalType.Integer
                 })

--- a/packages/content/src/attributes/types/name/PersonName.ts
+++ b/packages/content/src/attributes/types/name/PersonName.ts
@@ -1,5 +1,5 @@
 import { serialize, type, validate } from "@js-soft/ts-serval";
-import nameOf from "easy-tsnameof";
+import { nameof } from "ts-simple-nameof";
 import { AbstractAttributeValue } from "../../AbstractAttributeValue";
 import { AbstractComplexValue, AbstractComplexValueJSON, IAbstractComplexValue } from "../../AbstractComplexValue";
 import { RenderHints, ValueHints } from "../../hints";
@@ -28,8 +28,6 @@ export interface IPersonName extends IAbstractComplexValue {
 
 @type("PersonName")
 export class PersonName extends AbstractComplexValue implements IPersonName {
-    public static readonly propertyNames = nameOf<PersonName, never>();
-
     @serialize({ customGenerator: AbstractAttributeValue.valueGenerator })
     @validate()
     public givenName: GivenName;
@@ -53,11 +51,11 @@ export class PersonName extends AbstractComplexValue implements IPersonName {
     public static get valueHints(): ValueHints {
         return ValueHints.from({
             propertyHints: {
-                [this.propertyNames.givenName.$path]: GivenName.valueHints,
-                [this.propertyNames.middleName.$path]: MiddleName.valueHints,
-                [this.propertyNames.surname.$path]: Surname.valueHints,
-                [this.propertyNames.honorificSuffix.$path]: HonorificSuffix.valueHints,
-                [this.propertyNames.honorificPrefix.$path]: HonorificPrefix.valueHints
+                [nameof<PersonName>((p) => p.givenName)]: GivenName.valueHints,
+                [nameof<PersonName>((p) => p.middleName)]: MiddleName.valueHints,
+                [nameof<PersonName>((p) => p.surname)]: Surname.valueHints,
+                [nameof<PersonName>((p) => p.honorificSuffix)]: HonorificSuffix.valueHints,
+                [nameof<PersonName>((p) => p.honorificPrefix)]: HonorificPrefix.valueHints
             }
         });
     }
@@ -65,11 +63,11 @@ export class PersonName extends AbstractComplexValue implements IPersonName {
     public static override get renderHints(): RenderHints {
         return super.renderHints.copyWith({
             propertyHints: {
-                [this.propertyNames.givenName.$path]: GivenName.renderHints,
-                [this.propertyNames.middleName.$path]: MiddleName.renderHints,
-                [this.propertyNames.surname.$path]: Surname.renderHints,
-                [this.propertyNames.honorificSuffix.$path]: HonorificSuffix.renderHints,
-                [this.propertyNames.honorificPrefix.$path]: HonorificPrefix.renderHints
+                [nameof<PersonName>((p) => p.givenName)]: GivenName.renderHints,
+                [nameof<PersonName>((p) => p.middleName)]: MiddleName.renderHints,
+                [nameof<PersonName>((p) => p.surname)]: Surname.renderHints,
+                [nameof<PersonName>((p) => p.honorificSuffix)]: HonorificSuffix.renderHints,
+                [nameof<PersonName>((p) => p.honorificPrefix)]: HonorificPrefix.renderHints
             }
         });
     }

--- a/packages/content/src/attributes/types/statement/AbstractIdentityDescriptor.ts
+++ b/packages/content/src/attributes/types/statement/AbstractIdentityDescriptor.ts
@@ -1,8 +1,8 @@
 import { serialize, validate } from "@js-soft/ts-serval";
-import nameOf from "easy-tsnameof";
+import { nameof } from "ts-simple-nameof";
 import { AbstractComplexValue, AbstractComplexValueJSON, IAbstractComplexValue } from "../../../attributes/AbstractComplexValue";
 import { RenderHints, RenderHintsEditType, RenderHintsTechnicalType, ValueHints } from "../../../attributes/hints";
-import { IIdentityAttribute, IdentityAttribute, IdentityAttributeJSON } from "../../IdentityAttribute";
+import { IdentityAttribute, IdentityAttributeJSON, IIdentityAttribute } from "../../IdentityAttribute";
 
 export interface AbstractIdentityDescriptorJSON extends AbstractComplexValueJSON {
     attributes?: IdentityAttributeJSON[];
@@ -13,8 +13,6 @@ export interface IAbstractIdentityDescriptor extends IAbstractComplexValue {
 }
 
 export abstract class AbstractIdentityDescriptor extends AbstractComplexValue implements IAbstractIdentityDescriptor {
-    public static readonly propertyNames: any = nameOf<AbstractIdentityDescriptor, never>();
-
     // TODO: enable type
     // @serialize({ type: IdentityAttribute })
     @serialize()
@@ -24,7 +22,7 @@ export abstract class AbstractIdentityDescriptor extends AbstractComplexValue im
     public static get valueHints(): ValueHints {
         return ValueHints.from({
             propertyHints: {
-                [this.propertyNames.attributes.$path]: ValueHints.from({})
+                [nameof<AbstractIdentityDescriptor>((a) => a.attributes)]: ValueHints.from({})
             }
         });
     }
@@ -32,7 +30,7 @@ export abstract class AbstractIdentityDescriptor extends AbstractComplexValue im
     public static override get renderHints(): RenderHints {
         return super.renderHints.copyWith({
             propertyHints: {
-                [this.propertyNames.attributes.$path]: RenderHints.from({
+                [nameof<AbstractIdentityDescriptor>((a) => a.attributes)]: RenderHints.from({
                     editType: RenderHintsEditType.Complex,
                     technicalType: RenderHintsTechnicalType.Object
                 })

--- a/packages/content/src/attributes/types/statement/AbstractStatement.ts
+++ b/packages/content/src/attributes/types/statement/AbstractStatement.ts
@@ -1,5 +1,5 @@
 import { Serializable, serialize, validate, ValidationError } from "@js-soft/ts-serval";
-import nameOf from "easy-tsnameof";
+import { nameof } from "ts-simple-nameof";
 import { AbstractComplexValue, AbstractComplexValueJSON, IAbstractComplexValue } from "../../AbstractComplexValue";
 import { RenderHints, ValueHints } from "../../hints";
 import { DigitalIdentityDescriptor, DigitalIdentityDescriptorJSON, IDigitalIdentityDescriptor } from "./DigitalIdentityDescriptor";
@@ -25,8 +25,6 @@ export interface IAbstractStatement extends IAbstractComplexValue {
 }
 
 export abstract class AbstractStatement extends AbstractComplexValue implements IAbstractStatement {
-    public static readonly propertyNames: any = nameOf<AbstractStatement, never>();
-
     @serialize()
     @validate()
     public subject: StatementSubject;
@@ -53,10 +51,10 @@ export abstract class AbstractStatement extends AbstractComplexValue implements 
         if (value.predicate.value === Predicates.HasAttribute && (value.object.attributes?.length ?? 0) < 1) {
             throw new ValidationError(
                 this.constructor.name,
-                `${nameOf<AbstractStatement>((x) => x.object)}.${nameOf<StatementObject>((x) => x.attributes)}`,
-                `If the predicate of the Statement is '${Predicates.HasAttribute}' you have to define attributes in '${nameOf<AbstractStatement>(
+                `${nameof<AbstractStatement>((x) => x.object)}.${nameof<StatementObject>((x) => x.attributes)}`,
+                `If the predicate of the Statement is '${Predicates.HasAttribute}' you have to define attributes in '${nameof<AbstractStatement>(
                     (x) => x.object
-                )}.${nameOf<StatementObject>((x) => x.attributes)}'.`
+                )}.${nameof<StatementObject>((x) => x.attributes)}'.`
             );
         }
 
@@ -70,11 +68,11 @@ export abstract class AbstractStatement extends AbstractComplexValue implements 
     public static get valueHints(): ValueHints {
         return ValueHints.from({
             propertyHints: {
-                [this.propertyNames.subject.$path]: StatementSubject.valueHints,
-                [this.propertyNames.predicate.$path]: StatementPredicate.valueHints,
-                [this.propertyNames.object.$path]: StatementObject.valueHints,
-                [this.propertyNames.issuer.$path]: DigitalIdentityDescriptor.valueHints,
-                [this.propertyNames.issuerConditions.$path]: StatementIssuerConditions.valueHints
+                [nameof<AbstractStatement>((a) => a.subject)]: StatementSubject.valueHints,
+                [nameof<AbstractStatement>((a) => a.predicate)]: StatementPredicate.valueHints,
+                [nameof<AbstractStatement>((a) => a.object)]: StatementObject.valueHints,
+                [nameof<AbstractStatement>((a) => a.issuer)]: DigitalIdentityDescriptor.valueHints,
+                [nameof<AbstractStatement>((a) => a.issuerConditions)]: StatementIssuerConditions.valueHints
             }
         });
     }
@@ -82,11 +80,11 @@ export abstract class AbstractStatement extends AbstractComplexValue implements 
     public static override get renderHints(): RenderHints {
         return super.renderHints.copyWith({
             propertyHints: {
-                [this.propertyNames.subject.$path]: StatementSubject.renderHints,
-                [this.propertyNames.predicate.$path]: StatementPredicate.renderHints,
-                [this.propertyNames.object.$path]: StatementObject.renderHints,
-                [this.propertyNames.issuer.$path]: DigitalIdentityDescriptor.renderHints,
-                [this.propertyNames.issuerConditions.$path]: StatementIssuerConditions.renderHints
+                [nameof<AbstractStatement>((a) => a.subject)]: StatementSubject.renderHints,
+                [nameof<AbstractStatement>((a) => a.predicate)]: StatementPredicate.renderHints,
+                [nameof<AbstractStatement>((a) => a.object)]: StatementObject.renderHints,
+                [nameof<AbstractStatement>((a) => a.issuer)]: DigitalIdentityDescriptor.renderHints,
+                [nameof<AbstractStatement>((a) => a.issuerConditions)]: StatementIssuerConditions.renderHints
             }
         });
     }

--- a/packages/content/src/attributes/types/statement/DigitalIdentityDescriptor.ts
+++ b/packages/content/src/attributes/types/statement/DigitalIdentityDescriptor.ts
@@ -1,8 +1,8 @@
 import { serialize, type, validate } from "@js-soft/ts-serval";
 import { CoreAddress, ICoreAddress } from "@nmshd/transport";
-import nameOf from "easy-tsnameof";
 import { RenderHints, RenderHintsEditType, RenderHintsTechnicalType, ValueHints } from "../../../attributes/hints";
 
+import { nameof } from "ts-simple-nameof";
 import { AbstractIdentityDescriptor, AbstractIdentityDescriptorJSON, IAbstractIdentityDescriptor } from "./AbstractIdentityDescriptor";
 
 export interface DigitalIdentityDescriptorJSON extends AbstractIdentityDescriptorJSON {
@@ -16,8 +16,6 @@ export interface IDigitalIdentityDescriptor extends IAbstractIdentityDescriptor 
 
 @type("DigitalIdentityDescriptor")
 export class DigitalIdentityDescriptor extends AbstractIdentityDescriptor implements IDigitalIdentityDescriptor {
-    public static override readonly propertyNames: any = nameOf<DigitalIdentityDescriptor, never>();
-
     @serialize({ type: CoreAddress })
     @validate({ customValidator: (v) => (v.length < 1 ? "may not be empty" : undefined) })
     public address: CoreAddress;
@@ -33,7 +31,7 @@ export class DigitalIdentityDescriptor extends AbstractIdentityDescriptor implem
     public static override get valueHints(): ValueHints {
         return super.valueHints.copyWith({
             propertyHints: {
-                [this.propertyNames.address.$path]: ValueHints.from({})
+                [nameof<DigitalIdentityDescriptor>((d) => d.address)]: ValueHints.from({})
             }
         });
     }
@@ -41,7 +39,7 @@ export class DigitalIdentityDescriptor extends AbstractIdentityDescriptor implem
     public static override get renderHints(): RenderHints {
         return super.renderHints.copyWith({
             propertyHints: {
-                [this.propertyNames.address.$path]: RenderHints.from({
+                [nameof<DigitalIdentityDescriptor>((d) => d.address)]: RenderHints.from({
                     editType: RenderHintsEditType.InputLike,
                     technicalType: RenderHintsTechnicalType.String
                 })

--- a/packages/content/src/attributes/types/statement/StatementIssuerConditions.ts
+++ b/packages/content/src/attributes/types/statement/StatementIssuerConditions.ts
@@ -1,6 +1,6 @@
 import { serialize, type, validate } from "@js-soft/ts-serval";
 import { CoreDate, ICoreDate } from "@nmshd/transport";
-import nameOf from "easy-tsnameof";
+import { nameof } from "ts-simple-nameof";
 import { AbstractComplexValue, AbstractComplexValueJSON, IAbstractComplexValue } from "../../AbstractComplexValue";
 import { RenderHints, RenderHintsEditType, RenderHintsTechnicalType, ValueHints } from "../../hints";
 import { DigitalIdentityDescriptor } from "./DigitalIdentityDescriptor";
@@ -26,8 +26,6 @@ export interface IStatementIssuerConditions extends IAbstractComplexValue {
 
 @type("StatementIssuerConditions")
 export class StatementIssuerConditions extends AbstractComplexValue implements IStatementIssuerConditions {
-    public static readonly propertyNames: any = nameOf<StatementIssuerConditions, never>();
-
     @serialize()
     @validate()
     public validFrom: CoreDate;
@@ -59,11 +57,11 @@ export class StatementIssuerConditions extends AbstractComplexValue implements I
     public static get valueHints(): ValueHints {
         return ValueHints.from({
             propertyHints: {
-                [this.propertyNames.validFrom.$path]: ValueHints.from({}),
-                [this.propertyNames.validTo.$path]: ValueHints.from({}),
-                [this.propertyNames.evidence.$path]: StatementEvidence.valueHints,
-                [this.propertyNames.authorityType.$path]: StatementAuthorityType.valueHints,
-                [this.propertyNames.relayedParty.$path]: DigitalIdentityDescriptor.valueHints
+                [nameof<StatementIssuerConditions>((s) => s.validFrom)]: ValueHints.from({}),
+                [nameof<StatementIssuerConditions>((s) => s.validTo)]: ValueHints.from({}),
+                [nameof<StatementIssuerConditions>((s) => s.evidence)]: StatementEvidence.valueHints,
+                [nameof<StatementIssuerConditions>((s) => s.authorityType)]: StatementAuthorityType.valueHints,
+                [nameof<StatementIssuerConditions>((s) => s.relayedParty)]: DigitalIdentityDescriptor.valueHints
             }
         });
     }
@@ -71,17 +69,17 @@ export class StatementIssuerConditions extends AbstractComplexValue implements I
     public static override get renderHints(): RenderHints {
         return super.renderHints.copyWith({
             propertyHints: {
-                [this.propertyNames.validFrom.$path]: RenderHints.from({
+                [nameof<StatementIssuerConditions>((s) => s.validFrom)]: RenderHints.from({
                     editType: RenderHintsEditType.Secret,
                     technicalType: RenderHintsTechnicalType.String
                 }),
-                [this.propertyNames.validTo.$path]: RenderHints.from({
+                [nameof<StatementIssuerConditions>((s) => s.validTo)]: RenderHints.from({
                     editType: RenderHintsEditType.Secret,
                     technicalType: RenderHintsTechnicalType.String
                 }),
-                [this.propertyNames.evidence.$path]: StatementEvidence.renderHints,
-                [this.propertyNames.authorityType.$path]: StatementAuthorityType.renderHints,
-                [this.propertyNames.relayedParty.$path]: DigitalIdentityDescriptor.renderHints
+                [nameof<StatementIssuerConditions>((s) => s.evidence)]: StatementEvidence.renderHints,
+                [nameof<StatementIssuerConditions>((s) => s.authorityType)]: StatementAuthorityType.renderHints,
+                [nameof<StatementIssuerConditions>((s) => s.relayedParty)]: DigitalIdentityDescriptor.renderHints
             }
         });
     }

--- a/packages/content/src/attributes/types/statement/StatementObject.ts
+++ b/packages/content/src/attributes/types/statement/StatementObject.ts
@@ -1,6 +1,6 @@
 import { serialize, type, validate } from "@js-soft/ts-serval";
 import { CoreAddress, ICoreAddress } from "@nmshd/transport";
-import nameOf from "easy-tsnameof";
+import { nameof } from "ts-simple-nameof";
 import { RenderHints, RenderHintsEditType, RenderHintsTechnicalType, ValueHints } from "../../../attributes/hints";
 import { AbstractIdentityDescriptor, AbstractIdentityDescriptorJSON, IAbstractIdentityDescriptor } from "./AbstractIdentityDescriptor";
 
@@ -15,8 +15,6 @@ export interface IStatementObject extends IAbstractIdentityDescriptor {
 
 @type("StatementObject")
 export class StatementObject extends AbstractIdentityDescriptor implements IStatementObject {
-    public static override readonly propertyNames: any = nameOf<StatementObject, never>();
-
     @serialize({ type: CoreAddress })
     @validate({ customValidator: (v) => (v.length < 1 ? "may not be empty" : undefined) })
     public address: CoreAddress;
@@ -32,7 +30,7 @@ export class StatementObject extends AbstractIdentityDescriptor implements IStat
     public static override get valueHints(): ValueHints {
         return super.valueHints.copyWith({
             propertyHints: {
-                [this.propertyNames.address.$path]: ValueHints.from({})
+                [nameof<StatementObject>((d) => d.address)]: ValueHints.from({})
             }
         });
     }
@@ -40,7 +38,7 @@ export class StatementObject extends AbstractIdentityDescriptor implements IStat
     public static override get renderHints(): RenderHints {
         return super.renderHints.copyWith({
             propertyHints: {
-                [this.propertyNames.address.$path]: RenderHints.from({
+                [nameof<StatementObject>((d) => d.address)]: RenderHints.from({
                     editType: RenderHintsEditType.InputLike,
                     technicalType: RenderHintsTechnicalType.String
                 })

--- a/packages/content/src/attributes/types/statement/StatementSubject.ts
+++ b/packages/content/src/attributes/types/statement/StatementSubject.ts
@@ -1,6 +1,6 @@
 import { serialize, type, validate } from "@js-soft/ts-serval";
 import { CoreAddress, ICoreAddress } from "@nmshd/transport";
-import nameOf from "easy-tsnameof";
+import { nameof } from "ts-simple-nameof";
 import { RenderHints, RenderHintsEditType, RenderHintsTechnicalType, ValueHints } from "../../../attributes/hints";
 import { AbstractIdentityDescriptor, AbstractIdentityDescriptorJSON, IAbstractIdentityDescriptor } from "./AbstractIdentityDescriptor";
 
@@ -15,8 +15,6 @@ export interface IStatementSubject extends IAbstractIdentityDescriptor {
 
 @type("StatementSubject")
 export class StatementSubject extends AbstractIdentityDescriptor implements IStatementSubject {
-    public static override readonly propertyNames: any = nameOf<StatementSubject, never>();
-
     @serialize({ type: CoreAddress })
     @validate({ customValidator: (v) => (v.length < 1 ? "may not be empty" : undefined) })
     public address: CoreAddress;
@@ -32,7 +30,7 @@ export class StatementSubject extends AbstractIdentityDescriptor implements ISta
     public static override get valueHints(): ValueHints {
         return super.valueHints.copyWith({
             propertyHints: {
-                [this.propertyNames.address.$path]: ValueHints.from({})
+                [nameof<StatementSubject>((s) => s.address)]: ValueHints.from({})
             }
         });
     }
@@ -40,7 +38,7 @@ export class StatementSubject extends AbstractIdentityDescriptor implements ISta
     public static override get renderHints(): RenderHints {
         return super.renderHints.copyWith({
             propertyHints: {
-                [this.propertyNames.address.$path]: RenderHints.from({
+                [nameof<StatementSubject>((s) => s.address)]: RenderHints.from({
                     editType: RenderHintsEditType.InputLike,
                     technicalType: RenderHintsTechnicalType.String
                 })


### PR DESCRIPTION
easy-tsnameof is outdated and makes problems with the new typescript version: https://github.com/nmshd/runtime/pull/64 this PR can be merged afterwards

no version bumps needed for now, will do them in the bumpy pr #64 