### PR TITLE
fix/test race condition

### DIFF
--- a/packages/runtime/test/consumption/iqlQuery.test.ts
+++ b/packages/runtime/test/consumption/iqlQuery.test.ts
@@ -4,8 +4,8 @@ import { IQLQueryJSON, ReadAttributeRequestItemJSON } from "@nmshd/content";
 import { DateTime } from "luxon";
 import { ConsumptionServices, CreateOutgoingRequestRequest, LocalAttributeDTO, OutgoingRequestCreatedEvent, OutgoingRequestStatusChangedEvent, TransportServices } from "../../src";
 import { IncomingRequestReceivedEvent, IncomingRequestStatusChangedEvent } from "../../src/events";
-import { establishRelationship, exchangeMessageWithRequest, RuntimeServiceProvider, sendMessageWithRequest, TestRuntimeServices } from "../lib";
-import { exchangeMessageWithRequestAndRequireManualDecision, exchangeMessageWithRequestAndSendResponse } from "../lib/testUtilsWithInactiveModules";
+import { establishRelationship, RuntimeServiceProvider, sendMessageWithRequest, TestRuntimeServices } from "../lib";
+import { exchangeMessageWithRequest, exchangeMessageWithRequestAndRequireManualDecision, exchangeMessageWithRequestAndSendResponse } from "../lib/testUtilsWithInactiveModules";
 
 describe("IQL Query", () => {
     const runtimeServiceProvider = new RuntimeServiceProvider();

--- a/packages/runtime/test/consumption/requests.test.ts
+++ b/packages/runtime/test/consumption/requests.test.ts
@@ -11,16 +11,9 @@ import {
     TransportServices
 } from "../../src";
 import { IncomingRequestReceivedEvent, IncomingRequestStatusChangedEvent } from "../../src/events";
+import { establishRelationship, exchangeTemplate, RuntimeServiceProvider, sendMessageWithRequest, syncUntilHasRelationships, TestRuntimeServices } from "../lib";
 import {
-    establishRelationship,
     exchangeMessageWithRequest,
-    exchangeTemplate,
-    RuntimeServiceProvider,
-    sendMessageWithRequest,
-    syncUntilHasRelationships,
-    TestRuntimeServices
-} from "../lib";
-import {
     exchangeMessageWithRequestAndRequireManualDecision,
     exchangeMessageWithRequestAndSendResponse,
     exchangeTemplateAndReceiverRequiresManualDecision,

--- a/packages/runtime/test/lib/testUtils.ts
+++ b/packages/runtime/test/lib/testUtils.ts
@@ -256,7 +256,9 @@ export async function exchangeMessage(transportServicesCreator: TransportService
 
 export async function exchangeMessageWithRequest(sender: TestRuntimeServices, recipient: TestRuntimeServices, request: CreateOutgoingRequestRequest): Promise<MessageDTO> {
     const sentMessage = await sendMessageWithRequest(sender, recipient, request);
-    return await syncUntilHasMessageWithRequest(recipient.transport, sentMessage.content.id);
+    const receivedMessage = await syncUntilHasMessageWithRequest(recipient.transport, sentMessage.content.id);
+    await recipient.eventBus.waitForEvent(IncomingRequestStatusChangedEvent, (e) => e.data.newStatus === LocalRequestStatus.DecisionRequired);
+    return receivedMessage;
 }
 
 export async function exchangeMessageWithAttachment(transportServicesCreator: TransportServices, transportServicesRecipient: TransportServices): Promise<MessageDTO> {

--- a/packages/runtime/test/lib/testUtilsWithInactiveModules.ts
+++ b/packages/runtime/test/lib/testUtilsWithInactiveModules.ts
@@ -1,7 +1,7 @@
 import { IResponse, RelationshipCreationChangeRequestContent } from "@nmshd/content";
 import { CreateOutgoingRequestRequest, LocalRequestDTO, MessageDTO, RelationshipDTO } from "src";
 import { TestRuntimeServices } from "./RuntimeServiceProvider";
-import { exchangeMessageWithRequest, exchangeTemplate, syncUntilHasMessageWithResponse } from "./testUtils";
+import { exchangeTemplate, sendMessageWithRequest, syncUntilHasMessageWithRequest, syncUntilHasMessageWithResponse } from "./testUtils";
 
 export interface LocalRequestWithSource {
     request: LocalRequestDTO;
@@ -16,6 +16,11 @@ export interface ResponseMessagesForSenderAndRecipient {
 export interface RelationshipRequestWithRelationshipIfAccepted {
     request: LocalRequestDTO;
     relationship: RelationshipDTO | undefined;
+}
+
+export async function exchangeMessageWithRequest(sender: TestRuntimeServices, recipient: TestRuntimeServices, request: CreateOutgoingRequestRequest): Promise<MessageDTO> {
+    const sentMessage = await sendMessageWithRequest(sender, recipient, request);
+    return await syncUntilHasMessageWithRequest(recipient.transport, sentMessage.content.id);
 }
 
 export async function exchangeMessageWithRequestAndRequireManualDecision(


### PR DESCRIPTION
Decided to then have two methods called `exchangeMessageWithRequest` (one each for RequestModule active resp. inactive) since the inactive case is not expected to be used in any new tests. (This is also consistent with the inactive case methods not being exported anywhere except their file.)