### PR TITLE
Feature/Add ThirdPartyOwnedRelationshipAttributeSuccession

### DIFF
--- a/packages/consumption/src/consumption/CoreErrors.ts
+++ b/packages/consumption/src/consumption/CoreErrors.ts
@@ -85,6 +85,10 @@ class Attributes {
         return new CoreError("error.consumption.attributes.predecessorIsNotPeerSharedRelationshipAttribute", "Predecessor is not a peer shared relationship attribute.");
     }
 
+    public predecessorIsNotThirdPartyOwnedRelationshipAttribute() {
+        return new CoreError("error.consumption.attributes.predecessorIsNotThirdPartyOwnedRelationshipAttribute", "Predecessor is not a third party owned relationship attribute.");
+    }
+
     public successorIsNotRepositoryAttribute() {
         return new CoreError("error.consumption.attributes.successorIsNotRepositoryAttribute", "Successor is not a repository attribute.");
     }
@@ -103,6 +107,10 @@ class Attributes {
 
     public successorIsNotPeerSharedRelationshipAttribute() {
         return new CoreError("error.consumption.attributes.successorIsNotPeerSharedRelationshipAttribute", "Successor is not a peer shared relationship attribute.");
+    }
+
+    public successorIsNotThirdPartyOwnedRelationshipAttribute() {
+        return new CoreError("error.consumption.attributes.successorIsNotThirdPartyOwnedRelationshipAttribute", "Successor is not a third party owned relationship attribute.");
     }
 
     public setPredecessorIdDoesNotMatchActualPredecessorId() {

--- a/packages/consumption/src/modules/attributes/AttributesController.ts
+++ b/packages/consumption/src/modules/attributes/AttributesController.ts
@@ -406,7 +406,6 @@ export class AttributesController extends ConsumptionBaseController {
             succeededBy: parsedSuccessorParams.succeededBy
         });
 
-        // TODO: succeeding a peer shared IdentityAttribute in a different context than via a received PeerSharedAttributeSucceededNotificationItem, e.g. via AttributeSuccessionAcceptResponseItem, will not publish an event
         /* No succeeded attribute event fired here. This is done by the notification system. */
 
         return { predecessor, successor };
@@ -436,9 +435,6 @@ export class AttributesController extends ConsumptionBaseController {
             succeededBy: parsedSuccessorParams.succeededBy
         });
 
-        // TODO: succeeding a peer shared IdentityAttribute in a different context than via a received PeerSharedAttributeSucceededNotificationItem,
-        // TODO: e.g. via AttributeSuccessionAcceptResponseItem, will not publish an event
-        // TODO: -> perhaps we shouldn't return events in the NotificationItemProcessors
         /* No succeeded attribute event fired here. This is done by the notification system. */
 
         return { predecessor, successor };
@@ -969,10 +965,9 @@ export class AttributesController extends ConsumptionBaseController {
             throw TransportCoreErrors.general.recordNotFound(LocalAttribute, id.toString());
         }
 
-        // TODO:
-        // if (!repositoryAttribute.isRepositoryAttribute(this.identity.address)) {
-        //     throw CoreErrors.attributes.invalidPropertyValue(`Attribute '${id}' isn't a repository attribute.`);
-        // }
+        if (!repositoryAttribute.isRepositoryAttribute(this.identity.address)) {
+            throw CoreErrors.attributes.invalidPropertyValue(`Attribute '${id}' isn't a repository attribute.`);
+        }
 
         let i = 0;
         while (repositoryAttribute.succeededBy && i < 1000) {

--- a/packages/consumption/src/modules/attributes/AttributesController.ts
+++ b/packages/consumption/src/modules/attributes/AttributesController.ts
@@ -24,7 +24,14 @@ import { ConsumptionError } from "../../consumption/ConsumptionError";
 import { ConsumptionIds } from "../../consumption/ConsumptionIds";
 import { CoreErrors } from "../../consumption/CoreErrors";
 import { ValidationResult } from "../common";
-import { AttributeCreatedEvent, AttributeDeletedEvent, OwnSharedAttributeSucceededEvent, RepositoryAttributeSucceededEvent, SharedAttributeCopyCreatedEvent } from "./events";
+import {
+    AttributeCreatedEvent,
+    AttributeDeletedEvent,
+    OwnSharedAttributeSucceededEvent,
+    RepositoryAttributeSucceededEvent,
+    SharedAttributeCopyCreatedEvent,
+    ThirdPartyOwnedRelationshipAttributeSucceededEvent
+} from "./events";
 import { AttributeSuccessorParams, AttributeSuccessorParamsJSON, IAttributeSuccessorParams } from "./local/AttributeSuccessorParams";
 import { CreateLocalAttributeParams, ICreateLocalAttributeParams } from "./local/CreateLocalAttributeParams";
 import { ICreatePeerLocalAttributeParams } from "./local/CreatePeerLocalAttributeParams";
@@ -399,6 +406,7 @@ export class AttributesController extends ConsumptionBaseController {
             succeededBy: parsedSuccessorParams.succeededBy
         });
 
+        // TODO: succeeding a peer shared IdentityAttribute in a different context than via a received PeerSharedAttributeSucceededNotificationItem, e.g. via AttributeSuccessionAcceptResponseItem, will not publish an event
         /* No succeeded attribute event fired here. This is done by the notification system. */
 
         return { predecessor, successor };
@@ -428,7 +436,39 @@ export class AttributesController extends ConsumptionBaseController {
             succeededBy: parsedSuccessorParams.succeededBy
         });
 
+        // TODO: succeeding a peer shared IdentityAttribute in a different context than via a received PeerSharedAttributeSucceededNotificationItem,
+        // TODO: e.g. via AttributeSuccessionAcceptResponseItem, will not publish an event
+        // TODO: -> perhaps we shouldn't return events in the NotificationItemProcessors
         /* No succeeded attribute event fired here. This is done by the notification system. */
+
+        return { predecessor, successor };
+    }
+
+    public async succeedThirdPartyOwnedRelationshipAttribute(
+        predecessorId: CoreId,
+        successorParams: IAttributeSuccessorParams | AttributeSuccessorParamsJSON,
+        validate = true
+    ): Promise<{ predecessor: LocalAttribute; successor: LocalAttribute }> {
+        const parsedSuccessorParams = AttributeSuccessorParams.from(successorParams);
+
+        if (validate) {
+            const validationResult = await this.validateThirdPartyOwnedRelationshipAttributeSuccession(predecessorId, parsedSuccessorParams);
+            if (validationResult.isError()) {
+                throw validationResult.error;
+            }
+        }
+
+        const { predecessor, successor } = await this._succeedAttributeUnsafe(predecessorId, {
+            id: parsedSuccessorParams.id,
+            content: parsedSuccessorParams.content,
+            succeeds: predecessorId,
+            shareInfo: parsedSuccessorParams.shareInfo,
+            parentId: parsedSuccessorParams.parentId,
+            createdAt: parsedSuccessorParams.createdAt,
+            succeededBy: parsedSuccessorParams.succeededBy
+        });
+
+        this.eventBus.publish(new ThirdPartyOwnedRelationshipAttributeSucceededEvent(this.identity.address.toString(), predecessor, successor));
 
         return { predecessor, successor };
     }
@@ -741,6 +781,50 @@ export class AttributesController extends ConsumptionBaseController {
         return ValidationResult.success();
     }
 
+    public async validateThirdPartyOwnedRelationshipAttributeSuccession(
+        predecessorId: CoreId,
+        successorParams: IAttributeSuccessorParams | AttributeSuccessorParamsJSON
+    ): Promise<ValidationResult> {
+        let parsedSuccessorParams;
+        try {
+            parsedSuccessorParams = AttributeSuccessorParams.from(successorParams);
+        } catch (e: unknown) {
+            return ValidationResult.error(CoreErrors.attributes.successorIsNotAValidAttribute(e));
+        }
+
+        const commonValidation = await this.validateAttributeSuccessionCommon(predecessorId, parsedSuccessorParams);
+        if (commonValidation.isError()) return commonValidation;
+
+        const predecessor = (await this.getLocalAttribute(predecessorId))!;
+        const successor = LocalAttribute.from({
+            id: CoreId.from(parsedSuccessorParams.id ?? "dummy"),
+            content: parsedSuccessorParams.content,
+            createdAt: parsedSuccessorParams.createdAt ?? CoreDate.utc(),
+            succeeds: parsedSuccessorParams.succeeds,
+            succeededBy: parsedSuccessorParams.succeededBy,
+            shareInfo: parsedSuccessorParams.shareInfo,
+            parentId: parsedSuccessorParams.parentId
+        });
+
+        if (!predecessor.isThirdPartyOwnedRelationshipAttribute(this.identity.address)) {
+            return ValidationResult.error(CoreErrors.attributes.predecessorIsNotThirdPartyOwnedRelationshipAttribute());
+        }
+
+        if (!successor.isThirdPartyOwnedRelationshipAttribute(this.identity.address)) {
+            return ValidationResult.error(CoreErrors.attributes.successorIsNotThirdPartyOwnedRelationshipAttribute());
+        }
+
+        if (successor.content.key !== predecessor.content.key) {
+            return ValidationResult.error(CoreErrors.attributes.successionMustNotChangeKey());
+        }
+
+        if (!predecessor.shareInfo.peer.equals(successor.shareInfo.peer)) {
+            return ValidationResult.error(CoreErrors.attributes.successionMustNotChangePeer());
+        }
+
+        return ValidationResult.success();
+    }
+
     public async validateAttributeSuccessionCommon(predecessorId: CoreId, successorParams: IAttributeSuccessorParams | AttributeSuccessorParamsJSON): Promise<ValidationResult> {
         let parsedSuccessorParams;
         try {
@@ -885,9 +969,10 @@ export class AttributesController extends ConsumptionBaseController {
             throw TransportCoreErrors.general.recordNotFound(LocalAttribute, id.toString());
         }
 
-        if (!repositoryAttribute.isRepositoryAttribute(this.identity.address)) {
-            throw CoreErrors.attributes.invalidPropertyValue(`Attribute '${id}' isn't a repository attribute.`);
-        }
+        // TODO:
+        // if (!repositoryAttribute.isRepositoryAttribute(this.identity.address)) {
+        //     throw CoreErrors.attributes.invalidPropertyValue(`Attribute '${id}' isn't a repository attribute.`);
+        // }
 
         let i = 0;
         while (repositoryAttribute.succeededBy && i < 1000) {

--- a/packages/consumption/src/modules/attributes/events/ThirdPartyOwnedRelationshipAttributeSucceededEvent.ts
+++ b/packages/consumption/src/modules/attributes/events/ThirdPartyOwnedRelationshipAttributeSucceededEvent.ts
@@ -1,0 +1,11 @@
+import { TransportDataEvent } from "@nmshd/transport";
+import { LocalAttribute } from "../local/LocalAttribute";
+import { AttributeSucceededEventData } from "./AttributeSucceededEventData";
+
+export class ThirdPartyOwnedRelationshipAttributeSucceededEvent extends TransportDataEvent<AttributeSucceededEventData> {
+    public static readonly namespace = "consumption.thirdPartyOwnedRelationshipAttributeSucceded";
+
+    public constructor(eventTargetAddress: string, predecessor: LocalAttribute, successor: LocalAttribute) {
+        super(ThirdPartyOwnedRelationshipAttributeSucceededEvent.namespace, eventTargetAddress, { predecessor, successor });
+    }
+}

--- a/packages/consumption/src/modules/attributes/events/index.ts
+++ b/packages/consumption/src/modules/attributes/events/index.ts
@@ -5,3 +5,4 @@ export * from "./OwnSharedAttributeSucceededEvent";
 export * from "./PeerSharedAttributeSucceededEvent";
 export * from "./RepositoryAttributeSucceededEvent";
 export * from "./SharedAttributeCopyCreatedEvent";
+export * from "./ThirdPartyOwnedRelationshipAttributeSucceededEvent";

--- a/packages/consumption/src/modules/attributes/local/LocalAttribute.ts
+++ b/packages/consumption/src/modules/attributes/local/LocalAttribute.ts
@@ -51,6 +51,11 @@ export type PeerSharedRelationshipAttribute = LocalAttribute & {
     shareInfo: LocalAttributeShareInfo & { sourceAttribute: undefined };
 };
 
+export type ThirdPartyOwnedRelationshipAttribute = LocalAttribute & {
+    content: RelationshipAttribute;
+    shareInfo: LocalAttributeShareInfo & { sourceAttribute: CoreId };
+};
+
 export type RepositoryAttribute = LocalAttribute & {
     content: IdentityAttribute;
     shareInfo: undefined;
@@ -110,6 +115,10 @@ export class LocalAttribute extends CoreSynchronizable implements ILocalAttribut
         return this.isRelationshipAttribute() && this.isPeerSharedAttribute(peerAddress);
     }
 
+    public isThirdPartyOwnedRelationshipAttribute(ownAddress: CoreAddress, thirdPartyAddress?: CoreAddress): this is ThirdPartyOwnedRelationshipAttribute {
+        return this.isRelationshipAttribute() && this.isThirdPartyOwnedAttribute(ownAddress, thirdPartyAddress);
+    }
+
     public isRepositoryAttribute(ownAddress: CoreAddress): this is RepositoryAttribute {
         return this.isIdentityAttribute() && !this.isShared() && this.isOwnedBy(ownAddress);
     }
@@ -146,14 +155,26 @@ export class LocalAttribute extends CoreSynchronizable implements ILocalAttribut
         return isPeerSharedAttribute;
     }
 
+    public isThirdPartyOwnedAttribute(ownAddress: CoreAddress, thirdPartyAddress?: CoreAddress): this is ThirdPartyOwnedRelationshipAttribute {
+        let isThirdPartyOwnedAttribute = this.isShared() && !this.isOwnedBy(ownAddress) && !this.isOwnedBy(this.shareInfo.peer);
+        if (!isThirdPartyOwnedAttribute) {
+            return isThirdPartyOwnedAttribute;
+        }
+
+        if (typeof thirdPartyAddress !== "undefined") {
+            isThirdPartyOwnedAttribute &&= this.isOwnedBy(thirdPartyAddress);
+        }
+        return isThirdPartyOwnedAttribute;
+    }
+
     public isIdentityAttribute(): this is LocalAttribute & { content: IdentityAttribute } {
         return this.content instanceof IdentityAttribute;
     }
 
     public isRelationshipAttribute(): this is LocalAttribute & { content: RelationshipAttribute } & {
-        shareInfo: LocalAttributeShareInfo & { sourceAttribute: undefined };
+        shareInfo: LocalAttributeShareInfo;
     } {
-        return this.content instanceof RelationshipAttribute && this.isShared() && typeof this.shareInfo.sourceAttribute === "undefined";
+        return this.content instanceof RelationshipAttribute && this.isShared();
     }
 
     public isComplexAttribute(): boolean {

--- a/packages/consumption/test/modules/attributes/AttributesController.test.ts
+++ b/packages/consumption/test/modules/attributes/AttributesController.test.ts
@@ -1537,6 +1537,53 @@ describe("AttributesController", function () {
                 expect((predecessor.content.value.toJSON() as any).value).toBe("0815");
                 expect((successor.content.value.toJSON() as any).value).toBe("1337");
             });
+
+            test("should succeed a third party owned relationship attribute", async function () {
+                const predecessor = await consumptionController.attributes.createLocalAttribute({
+                    content: RelationshipAttribute.from({
+                        key: "customerId",
+                        value: {
+                            "@type": "ProprietaryString",
+                            value: "0815",
+                            title: "Customer ID"
+                        },
+                        owner: CoreAddress.from("thirdPartyAddress"),
+                        confidentiality: RelationshipAttributeConfidentiality.Public
+                    }),
+                    shareInfo: {
+                        peer: CoreAddress.from("peerAddress"),
+                        requestReference: CoreId.from("reqRefA")
+                    }
+                });
+                const successorParams: IAttributeSuccessorParams = {
+                    content: RelationshipAttribute.from({
+                        key: "customerId",
+                        value: {
+                            "@type": "ProprietaryString",
+                            value: "1337",
+                            title: "Customer ID"
+                        },
+                        owner: CoreAddress.from("thirdPartyAddress"),
+                        confidentiality: RelationshipAttributeConfidentiality.Public
+                    }),
+                    shareInfo: {
+                        peer: CoreAddress.from("peerAddress"),
+                        requestReference: CoreId.from("reqRefB")
+                    }
+                };
+
+                const { predecessor: updatedPredecessor, successor } = await consumptionController.attributes.succeedThirdPartyOwnedRelationshipAttribute(
+                    predecessor.id,
+                    successorParams
+                );
+                expect(successor).toBeDefined();
+                expect(updatedPredecessor).toBeDefined();
+                expect(predecessor.id.equals(updatedPredecessor.id)).toBe(true);
+                expect(updatedPredecessor.succeededBy!.equals(successor.id)).toBe(true);
+                expect(successor.succeeds!.equals(updatedPredecessor.id)).toBe(true);
+                expect((predecessor.content.value.toJSON() as any).value).toBe("0815");
+                expect((successor.content.value.toJSON() as any).value).toBe("1337");
+            });
         });
     });
 

--- a/packages/runtime/src/events/EventProxy.ts
+++ b/packages/runtime/src/events/EventProxy.ts
@@ -14,7 +14,8 @@ import {
     OutgoingRequestStatusChangedEvent,
     OwnSharedAttributeSucceededEvent,
     PeerSharedAttributeSucceededEvent,
-    RepositoryAttributeSucceededEvent
+    RepositoryAttributeSucceededEvent,
+    ThirdPartyOwnedRelationshipAttributeSucceededEvent
 } from "./consumption";
 import {
     MessageDeliveredEvent,
@@ -88,6 +89,15 @@ export class EventProxy {
         this.subscribeToSourceEvent(consumption.PeerSharedAttributeSucceededEvent, (event) => {
             this.targetEventBus.publish(
                 new PeerSharedAttributeSucceededEvent(event.eventTargetAddress, {
+                    predecessor: AttributeMapper.toAttributeDTO(event.data.predecessor),
+                    successor: AttributeMapper.toAttributeDTO(event.data.successor)
+                })
+            );
+        });
+
+        this.subscribeToSourceEvent(consumption.ThirdPartyOwnedRelationshipAttributeSucceededEvent, (event) => {
+            this.targetEventBus.publish(
+                new ThirdPartyOwnedRelationshipAttributeSucceededEvent(event.eventTargetAddress, {
                     predecessor: AttributeMapper.toAttributeDTO(event.data.predecessor),
                     successor: AttributeMapper.toAttributeDTO(event.data.successor)
                 })

--- a/packages/runtime/src/events/consumption/ThirdPartyOwnedRelationshipAttributeSucceededEvent.ts
+++ b/packages/runtime/src/events/consumption/ThirdPartyOwnedRelationshipAttributeSucceededEvent.ts
@@ -1,0 +1,10 @@
+import { DataEvent } from "../DataEvent";
+import { SuccessionEventData } from "./SuccessionEventData";
+
+export class ThirdPartyOwnedRelationshipAttributeSucceededEvent extends DataEvent<SuccessionEventData> {
+    public static readonly namespace = "consumption.thirdPartyOwnedRelationshipAttributeSucceeded";
+
+    public constructor(eventTargetAddress: string, data: SuccessionEventData) {
+        super(ThirdPartyOwnedRelationshipAttributeSucceededEvent.namespace, eventTargetAddress, data);
+    }
+}

--- a/packages/runtime/src/events/consumption/index.ts
+++ b/packages/runtime/src/events/consumption/index.ts
@@ -16,3 +16,4 @@ export * from "./RelationshipEvent";
 export * from "./RelationshipTemplateProcessedEvent";
 export * from "./RepositoryAttributeSucceededEvent";
 export * from "./SuccessionEventData";
+export * from "./ThirdPartyOwnedRelationshipAttributeSucceededEvent";


### PR DESCRIPTION
This will be necessary, if we aim for a correct succession, sharing the successor of an already shared third party RelationshipAttribute as a Response for a ReadAttributeRequestItem or ProposeAttributeRequestItem.