### PR TITLE
Feature/Detach ThirdPartyRelationshipAttributes

### DIFF
--- a/packages/consumption/src/modules/attributes/AttributesController.ts
+++ b/packages/consumption/src/modules/attributes/AttributesController.ts
@@ -878,37 +878,37 @@ export class AttributesController extends ConsumptionBaseController {
         await this.attributes.delete({ id: id });
     }
 
-    public async deleteRepositoryAttribute(sourceAttribute: LocalAttribute): Promise<void> {
-        const validationResult = await this.validateSourceAttributeDeletion(sourceAttribute);
+    public async executeFullAttributeDeletionProcess(attribute: LocalAttribute): Promise<void> {
+        const validationResult = await this.validateFullAttributeDeletionProcess(attribute);
         if (validationResult.isError()) {
             throw validationResult.error;
         }
 
-        if (typeof sourceAttribute.succeededBy !== "undefined") {
-            const successor = await this.getLocalAttribute(sourceAttribute.succeededBy);
+        if (typeof attribute.succeededBy !== "undefined") {
+            const successor = await this.getLocalAttribute(attribute.succeededBy);
             if (typeof successor === "undefined") {
                 throw CoreErrors.attributes.successorDoesNotExist();
             }
             await this.detachSuccessor(successor);
         }
 
-        const attributeCopies = await this.getLocalAttributes({ "shareInfo.sourceAttribute": sourceAttribute.id.toString() });
-        const attributePredecessorCopies = await this.getSharedPredecessorsOfRepositoryAttribute(sourceAttribute);
+        const attributeCopies = await this.getLocalAttributes({ "shareInfo.sourceAttribute": attribute.id.toString() });
+        const attributePredecessorCopies = await this.getSharedPredecessorsOfRepositoryAttribute(attribute);
         const attributeCopiesToDetach = [...attributeCopies, ...attributePredecessorCopies];
         await this.detachAttributeCopies(attributeCopiesToDetach);
 
-        await this.deletePredecessorsOfAttribute(sourceAttribute.id);
-        await this.deleteAttribute(sourceAttribute);
+        await this.deletePredecessorsOfAttribute(attribute.id);
+        await this.deleteAttribute(attribute);
     }
 
-    public async validateSourceAttributeDeletion(sourceAttribute: LocalAttribute): Promise<ValidationResult> {
-        const validateSuccessorResult = await this.validateSuccessor(sourceAttribute);
+    public async validateFullAttributeDeletionProcess(attribute: LocalAttribute): Promise<ValidationResult> {
+        const validateSuccessorResult = await this.validateSuccessor(attribute);
         if (validateSuccessorResult.isError()) {
             return validateSuccessorResult;
         }
 
-        const attributeCopies = await this.getLocalAttributes({ "shareInfo.sourceAttribute": sourceAttribute.id.toString() });
-        const attributePredecessorCopies = await this.getSharedPredecessorsOfRepositoryAttribute(sourceAttribute);
+        const attributeCopies = await this.getLocalAttributes({ "shareInfo.sourceAttribute": attribute.id.toString() });
+        const attributePredecessorCopies = await this.getSharedPredecessorsOfRepositoryAttribute(attribute);
         const attributeCopiesToDetach = [...attributeCopies, ...attributePredecessorCopies];
 
         const validateSharedAttributesResult = this.validateSharedAttributes(attributeCopiesToDetach);

--- a/packages/runtime/src/useCases/consumption/attributes/DeleteRepositoryAttribute.ts
+++ b/packages/runtime/src/useCases/consumption/attributes/DeleteRepositoryAttribute.ts
@@ -34,12 +34,12 @@ export class DeleteRepositoryAttributeUseCase extends UseCase<DeleteRepositoryAt
             return Result.fail(RuntimeErrors.attributes.isNotRepositoryAttribute(CoreId.from(request.attributeId)));
         }
 
-        const validationResult = await this.attributesController.validateSourceAttributeDeletion(repositoryAttribute);
+        const validationResult = await this.attributesController.validateFullAttributeDeletionProcess(repositoryAttribute);
         if (validationResult.isError()) {
             return Result.fail(validationResult.error);
         }
 
-        await this.attributesController.deleteRepositoryAttribute(repositoryAttribute);
+        await this.attributesController.executeFullAttributeDeletionProcess(repositoryAttribute);
 
         await this.accountController.syncDatawallet();
 

--- a/packages/runtime/test/lib/testUtils.ts
+++ b/packages/runtime/test/lib/testUtils.ts
@@ -513,10 +513,11 @@ export async function waitForRecipientToReceiveNotification(
 }
 
 /**
- * Creates a repository attribute on sender's side and shares it with
- * recipient, waiting for all communication and event processing to finish.
+ * The owner of a RelationshipAttribute receives a Request of a
+ * peer and forwards them the ThirdPartyRelationshipAttribute,
+ * waiting for all communication and event processing to finish.
  *
- * Returns the sender's own shared identity attribute.
+ * Returns the sender's own shared ThirdPartyRelationshipAttribute.
  */
 export async function executeFullRequestAndShareThirdPartyRelationshipAttributeFlow(
     owner: TestRuntimeServices,

--- a/packages/runtime/test/lib/testUtils.ts
+++ b/packages/runtime/test/lib/testUtils.ts
@@ -1,5 +1,11 @@
 import { EventBus, sleep, SubscriptionTarget } from "@js-soft/ts-utils";
-import { ConsumptionIds, DecideRequestItemGroupParametersJSON, DecideRequestItemParametersJSON, LocalRequestStatus } from "@nmshd/consumption";
+import {
+    AcceptReadAttributeRequestItemParametersWithExistingAttributeJSON,
+    ConsumptionIds,
+    DecideRequestItemGroupParametersJSON,
+    DecideRequestItemParametersJSON,
+    LocalRequestStatus
+} from "@nmshd/consumption";
 import {
     INotificationItem,
     IRelationshipCreationChangeRequestContent,
@@ -504,6 +510,40 @@ export async function waitForRecipientToReceiveNotification(
     await recipient.eventBus.waitForEvent(PeerSharedAttributeSucceededEvent, (e) => {
         return e.data.successor.id === notifyRequestResult.successor.id;
     });
+}
+
+/**
+ * Creates a repository attribute on sender's side and shares it with
+ * recipient, waiting for all communication and event processing to finish.
+ *
+ * Returns the sender's own shared identity attribute.
+ */
+export async function executeFullRequestAndShareThirdPartyRelationshipAttributeFlow(
+    owner: TestRuntimeServices,
+    peer: TestRuntimeServices,
+    request: CreateOutgoingRequestRequest,
+    attributeId: string
+): Promise<LocalAttributeDTO> {
+    const localRequest = (await peer.consumption.outgoingRequests.create(request)).value;
+    await peer.transport.messages.sendMessage({ recipients: [owner.address], content: localRequest.content });
+
+    await syncUntilHasMessageWithRequest(owner.transport, localRequest.id);
+    await owner.eventBus.waitForEvent(IncomingRequestStatusChangedEvent, (e) => {
+        return e.data.request.id === localRequest.id && e.data.newStatus === LocalRequestStatus.ManualDecisionRequired;
+    });
+    await owner.consumption.incomingRequests.accept({
+        requestId: localRequest.id,
+        items: [{ accept: true, existingAttributeId: attributeId } as AcceptReadAttributeRequestItemParametersWithExistingAttributeJSON]
+    });
+
+    const responseMessage = await syncUntilHasMessageWithResponse(peer.transport, localRequest.id);
+    const sharedAttributeId = responseMessage.content.response.items[0].attributeId;
+    await peer.eventBus.waitForEvent(OutgoingRequestStatusChangedEvent, (e) => {
+        return e.data.request.id === localRequest.id && e.data.newStatus === LocalRequestStatus.Completed;
+    });
+
+    const ownSharedThirdPartyRelationshipAttribute = (await owner.consumption.attributes.getAttribute({ id: sharedAttributeId })).value;
+    return ownSharedThirdPartyRelationshipAttribute;
 }
 
 /**


### PR DESCRIPTION
Deleting a RelationshipAttribute, that is the sourceAttribute of a ThirdPartyRelationshipAttribute, their respective sourceAttribute property will be unset.