### PR TITLE
Feature/Delete third party owned RelationshipAttribute use case

### DIFF
--- a/packages/consumption/src/consumption/ConsumptionController.ts
+++ b/packages/consumption/src/consumption/ConsumptionController.ts
@@ -10,7 +10,8 @@ import {
     ProposeAttributeRequestItem,
     ReadAttributeRequestItem,
     RegisterAttributeListenerRequestItem,
-    ShareAttributeRequestItem
+    ShareAttributeRequestItem,
+    ThirdPartyOwnedRelationshipAttributeDeletedByPeerNotificationItem
 } from "@nmshd/content";
 import { AccountController, Transport } from "@nmshd/transport";
 import {
@@ -37,7 +38,8 @@ import {
     RequestItemProcessorConstructor,
     RequestItemProcessorRegistry,
     SettingsController,
-    ShareAttributeRequestItemProcessor
+    ShareAttributeRequestItemProcessor,
+    ThirdPartyOwnedRelationshipAttributeDeletedByPeerNotificationItemProcessor
 } from "../modules";
 
 export class ConsumptionController {
@@ -146,8 +148,9 @@ export class ConsumptionController {
     private getDefaultNotificationItemProcessors() {
         return new Map<NotificationItemConstructor, NotificationItemProcessorConstructor>([
             [PeerSharedAttributeSucceededNotificationItem, PeerSharedAttributeSucceededNotificationItemProcessor],
+            [OwnSharedAttributeDeletedByOwnerNotificationItem, OwnSharedAttributeDeletedByOwnerNotificationItemProcessor],
             [PeerSharedAttributeDeletedByPeerNotificationItem, PeerSharedAttributeDeletedByPeerNotificationItemProcessor],
-            [OwnSharedAttributeDeletedByOwnerNotificationItem, OwnSharedAttributeDeletedByOwnerNotificationItemProcessor]
+            [ThirdPartyOwnedRelationshipAttributeDeletedByPeerNotificationItem, ThirdPartyOwnedRelationshipAttributeDeletedByPeerNotificationItemProcessor]
         ]);
     }
 }

--- a/packages/consumption/src/consumption/CoreErrors.ts
+++ b/packages/consumption/src/consumption/CoreErrors.ts
@@ -217,6 +217,13 @@ class Attributes {
         return new CoreError("error.consumption.attributes.isNotPeerSharedAttribute", `The attribute (id: ${attributeId}) is not a peer shared attribute.`);
     }
 
+    public isNotThirdPartyOwnedRelationshipAttribute(attributeId: string | CoreId) {
+        return new CoreError(
+            "error.consumption.attributes.isNotThirdPartyOwnedRelationshipAttribute",
+            `The attribute (id: ${attributeId}) is not a third party owned RelationshipAttribute.`
+        );
+    }
+
     public senderIsNotPeerOfSharedAttribute(senderId: string | CoreAddress, attributeId: string | CoreId) {
         return new CoreError(
             "error.consumption.attributes.senderIsNotPeerOfSharedAttribute",

--- a/packages/consumption/src/modules/attributes/events/ThirdPartyOwnedRelationshipAttributeDeletedByPeerEvent.ts
+++ b/packages/consumption/src/modules/attributes/events/ThirdPartyOwnedRelationshipAttributeDeletedByPeerEvent.ts
@@ -1,0 +1,10 @@
+import { TransportDataEvent } from "@nmshd/transport";
+import { LocalAttribute } from "../local/LocalAttribute";
+
+export class ThirdPartyOwnedRelationshipAttributeDeletedByPeerEvent extends TransportDataEvent<LocalAttribute> {
+    public static readonly namespace = "consumption.thirdPartyOwnedRelationshipAttributeDeletedByPeer";
+
+    public constructor(eventTargetAddress: string, data: LocalAttribute) {
+        super(ThirdPartyOwnedRelationshipAttributeDeletedByPeerEvent.namespace, eventTargetAddress, data);
+    }
+}

--- a/packages/consumption/src/modules/attributes/events/index.ts
+++ b/packages/consumption/src/modules/attributes/events/index.ts
@@ -7,3 +7,4 @@ export * from "./PeerSharedAttributeDeletedByPeerEvent";
 export * from "./PeerSharedAttributeSucceededEvent";
 export * from "./RepositoryAttributeSucceededEvent";
 export * from "./SharedAttributeCopyCreatedEvent";
+export * from "./ThirdPartyOwnedRelationshipAttributeDeletedByPeerEvent";

--- a/packages/consumption/src/modules/attributes/local/LocalAttribute.ts
+++ b/packages/consumption/src/modules/attributes/local/LocalAttribute.ts
@@ -134,9 +134,6 @@ export class LocalAttribute extends CoreSynchronizable implements ILocalAttribut
 
     public isOwnSharedAttribute(ownAddress: CoreAddress, peerAddress?: CoreAddress): this is OwnSharedIdentityAttribute | OwnSharedRelationshipAttribute {
         let isOwnSharedAttribute = this.isShared() && this.isOwnedBy(ownAddress);
-        if (!isOwnSharedAttribute) {
-            return isOwnSharedAttribute;
-        }
 
         if (typeof peerAddress !== "undefined") {
             isOwnSharedAttribute &&= this.shareInfo!.peer.equals(peerAddress);
@@ -146,13 +143,8 @@ export class LocalAttribute extends CoreSynchronizable implements ILocalAttribut
 
     public isPeerSharedAttribute(peerAddress?: CoreAddress): this is PeerSharedIdentityAttribute | PeerSharedRelationshipAttribute {
         let isPeerSharedAttribute = this.isShared() && this.isOwnedBy(this.shareInfo.peer);
-        if (!isPeerSharedAttribute) {
-            return isPeerSharedAttribute;
-        }
 
-        if (this.isIdentityAttribute()) {
-            isPeerSharedAttribute &&= typeof this.shareInfo!.sourceAttribute === "undefined";
-        }
+        isPeerSharedAttribute &&= typeof this.shareInfo!.sourceAttribute === "undefined";
 
         if (typeof peerAddress !== "undefined") {
             isPeerSharedAttribute &&= this.isOwnedBy(peerAddress);
@@ -162,9 +154,6 @@ export class LocalAttribute extends CoreSynchronizable implements ILocalAttribut
 
     public isThirdPartyOwnedAttribute(ownAddress: CoreAddress, thirdPartyAddress?: CoreAddress): this is ThirdPartyOwnedRelationshipAttribute {
         let isThirdPartyOwnedAttribute = this.isShared() && !this.isOwnedBy(ownAddress) && !this.isOwnedBy(this.shareInfo.peer);
-        if (!isThirdPartyOwnedAttribute) {
-            return isThirdPartyOwnedAttribute;
-        }
 
         if (typeof thirdPartyAddress !== "undefined") {
             isThirdPartyOwnedAttribute &&= this.isOwnedBy(thirdPartyAddress);

--- a/packages/consumption/src/modules/attributes/local/LocalAttribute.ts
+++ b/packages/consumption/src/modules/attributes/local/LocalAttribute.ts
@@ -57,7 +57,7 @@ export type PeerSharedRelationshipAttribute = LocalAttribute & {
 
 export type ThirdPartyOwnedRelationshipAttribute = LocalAttribute & {
     content: RelationshipAttribute;
-    shareInfo: LocalAttributeShareInfo & { sourceAttribute: CoreId };
+    shareInfo: LocalAttributeShareInfo;
 };
 
 export type RepositoryAttribute = LocalAttribute & {

--- a/packages/consumption/src/modules/notifications/index.ts
+++ b/packages/consumption/src/modules/notifications/index.ts
@@ -1,6 +1,7 @@
 export * from "./itemProcessors/AbstractNotificationItemProcessor";
 export * from "./itemProcessors/attributeDeleted/OwnSharedAttributeDeletedByOwnerNotificationItemProcessor";
 export * from "./itemProcessors/attributeDeleted/PeerSharedAttributeDeletedByPeerNotificationItemProcessor";
+export * from "./itemProcessors/attributeDeleted/ThirdPartyOwnedRelationshipAttributeDeletedByPeerNotificationItemProcessor";
 export * from "./itemProcessors/attributeSucceeded/PeerSharedAttributeSucceededNotificationItemProcessor";
 export * from "./itemProcessors/NotificationItemConstructor";
 export * from "./itemProcessors/NotificationItemProcessorConstructor";

--- a/packages/consumption/src/modules/notifications/itemProcessors/attributeDeleted/ThirdPartyOwnedRelationshipAttributeDeletedByPeerNotificationItemProcessor.ts
+++ b/packages/consumption/src/modules/notifications/itemProcessors/attributeDeleted/ThirdPartyOwnedRelationshipAttributeDeletedByPeerNotificationItemProcessor.ts
@@ -1,0 +1,76 @@
+import { ILogger } from "@js-soft/logging-abstractions";
+import { ThirdPartyOwnedRelationshipAttributeDeletedByPeerNotificationItem } from "@nmshd/content";
+import { CoreDate, TransportLoggerFactory } from "@nmshd/transport";
+import { ConsumptionController } from "../../../../consumption/ConsumptionController";
+import { CoreErrors } from "../../../../consumption/CoreErrors";
+import { ThirdPartyOwnedRelationshipAttributeDeletedByPeerEvent } from "../../../attributes";
+import { DeletionStatus, LocalAttributeDeletionInfo } from "../../../attributes/local/LocalAttributeDeletionInfo";
+import { ValidationResult } from "../../../common";
+import { LocalNotification } from "../../local/LocalNotification";
+import { AbstractNotificationItemProcessor } from "../AbstractNotificationItemProcessor";
+
+export class ThirdPartyOwnedRelationshipAttributeDeletedByPeerNotificationItemProcessor extends AbstractNotificationItemProcessor<ThirdPartyOwnedRelationshipAttributeDeletedByPeerNotificationItem> {
+    private readonly _logger: ILogger;
+
+    public constructor(consumptionController: ConsumptionController) {
+        super(consumptionController);
+        this._logger = TransportLoggerFactory.getLogger(ThirdPartyOwnedRelationshipAttributeDeletedByPeerNotificationItemProcessor);
+    }
+
+    public override async checkPrerequisitesOfIncomingNotificationItem(
+        notificationItem: ThirdPartyOwnedRelationshipAttributeDeletedByPeerNotificationItem,
+        notification: LocalNotification
+    ): Promise<ValidationResult> {
+        const attribute = await this.consumptionController.attributes.getLocalAttribute(notificationItem.attributeId);
+
+        if (typeof attribute === "undefined") {
+            return ValidationResult.success();
+        }
+
+        if (!attribute.isThirdPartyOwnedRelationshipAttribute(this.currentIdentityAddress)) {
+            return ValidationResult.error(CoreErrors.attributes.isNotThirdPartyOwnedRelationshipAttribute(notificationItem.attributeId));
+        }
+
+        if (!notification.peer.equals(attribute.shareInfo.peer)) {
+            return ValidationResult.error(CoreErrors.attributes.senderIsNotPeerOfSharedAttribute(notification.peer, notificationItem.attributeId));
+        }
+
+        return ValidationResult.success();
+    }
+
+    public override async process(
+        notificationItem: ThirdPartyOwnedRelationshipAttributeDeletedByPeerNotificationItem,
+        _notification: LocalNotification
+    ): Promise<ThirdPartyOwnedRelationshipAttributeDeletedByPeerEvent | void> {
+        const attribute = await this.consumptionController.attributes.getLocalAttribute(notificationItem.attributeId);
+        if (typeof attribute === "undefined") return;
+
+        const deletionDate = CoreDate.utc();
+        const deletionInfo = LocalAttributeDeletionInfo.from({
+            deletionStatus: DeletionStatus.DeletedByPeer,
+            deletionDate: deletionDate
+        });
+
+        const predecessors = await this.consumptionController.attributes.getPredecessorsOfAttribute(attribute.id);
+
+        for (const attr of [attribute, ...predecessors]) {
+            attr.setDeletionInfo(deletionInfo, this.accountController.identity.address);
+            await this.consumptionController.attributes.updateAttributeUnsafe(attr);
+        }
+
+        return new ThirdPartyOwnedRelationshipAttributeDeletedByPeerEvent(this.currentIdentityAddress.toString(), attribute);
+    }
+
+    public override async rollback(notificationItem: ThirdPartyOwnedRelationshipAttributeDeletedByPeerNotificationItem, _notification: LocalNotification): Promise<void> {
+        const attribute = await this.consumptionController.attributes.getLocalAttribute(notificationItem.attributeId);
+        if (typeof attribute === "undefined") return;
+
+        const predecessors = await this.consumptionController.attributes.getPredecessorsOfAttribute(attribute.id);
+
+        for (const attr of [attribute, ...predecessors]) {
+            // the previous deletionState cannot be unambiguously known, either it was undefined or 'toBeDeletedByPeer'
+            attr.deletionInfo = undefined;
+            await this.consumptionController.attributes.updateAttributeUnsafe(attr);
+        }
+    }
+}

--- a/packages/consumption/test/modules/notifications/itemProcessors/attributeDeleted/ThirdPartyOwnedRelationshipAttributeDeletedByPeerNotificationItemProcessor.test.ts
+++ b/packages/consumption/test/modules/notifications/itemProcessors/attributeDeleted/ThirdPartyOwnedRelationshipAttributeDeletedByPeerNotificationItemProcessor.test.ts
@@ -1,11 +1,5 @@
 import { IDatabaseConnection } from "@js-soft/docdb-access-abstractions";
-import {
-    Notification,
-    PeerSharedAttributeDeletedByPeerNotificationItem,
-    RelationshipAttribute,
-    RelationshipAttributeConfidentiality,
-    ThirdPartyOwnedRelationshipAttributeDeletedByPeerNotificationItem
-} from "@nmshd/content";
+import { Notification, RelationshipAttribute, RelationshipAttributeConfidentiality, ThirdPartyOwnedRelationshipAttributeDeletedByPeerNotificationItem } from "@nmshd/content";
 import { AccountController, CoreAddress, CoreDate, CoreId, Transport } from "@nmshd/transport";
 import {
     ConsumptionController,
@@ -77,7 +71,7 @@ describe("ThirdPartyOwnedRelationshipAttributeDeletedByPeerNotificationItemProce
             }
         });
 
-        const notificationItem = PeerSharedAttributeDeletedByPeerNotificationItem.from({
+        const notificationItem = ThirdPartyOwnedRelationshipAttributeDeletedByPeerNotificationItem.from({
             attributeId: thirdPartyOwnedRelationshipAttribute.id
         });
         const notification = LocalNotification.from({

--- a/packages/consumption/test/modules/notifications/itemProcessors/attributeDeleted/ThirdPartyOwnedRelationshipAttributeDeletedByPeerNotificationItemProcessor.test.ts
+++ b/packages/consumption/test/modules/notifications/itemProcessors/attributeDeleted/ThirdPartyOwnedRelationshipAttributeDeletedByPeerNotificationItemProcessor.test.ts
@@ -1,0 +1,203 @@
+import { IDatabaseConnection } from "@js-soft/docdb-access-abstractions";
+import {
+    Notification,
+    PeerSharedAttributeDeletedByPeerNotificationItem,
+    RelationshipAttribute,
+    RelationshipAttributeConfidentiality,
+    ThirdPartyOwnedRelationshipAttributeDeletedByPeerNotificationItem
+} from "@nmshd/content";
+import { AccountController, CoreAddress, CoreDate, CoreId, Transport } from "@nmshd/transport";
+import {
+    ConsumptionController,
+    DeletionStatus,
+    LocalNotification,
+    LocalNotificationSource,
+    LocalNotificationStatus,
+    ThirdPartyOwnedRelationshipAttributeDeletedByPeerEvent,
+    ThirdPartyOwnedRelationshipAttributeDeletedByPeerNotificationItemProcessor
+} from "../../../../../src";
+import { TestUtil } from "../../../../core/TestUtil";
+import { MockEventBus } from "../../../MockEventBus";
+
+const mockEventBus = new MockEventBus();
+
+describe("ThirdPartyOwnedRelationshipAttributeDeletedByPeerNotificationItemProcessor", function () {
+    let connection: IDatabaseConnection;
+    let transport: Transport;
+
+    let consumptionController: ConsumptionController;
+    let testAccount: AccountController;
+
+    beforeAll(async function () {
+        connection = await TestUtil.createConnection();
+        transport = TestUtil.createTransport(connection, mockEventBus);
+
+        await transport.init();
+
+        const account = (await TestUtil.provideAccounts(transport, 1))[0];
+        ({ accountController: testAccount, consumptionController } = account);
+    });
+
+    afterAll(async function () {
+        await testAccount.close();
+        await connection.close();
+    });
+
+    beforeEach(async function () {
+        const attributes = await consumptionController.attributes.getLocalAttributes();
+        for (const attribute of attributes) {
+            await consumptionController.attributes.deleteAttributeUnsafe(attribute.id);
+        }
+        mockEventBus.clearPublishedEvents();
+    });
+
+    afterEach(async function () {
+        const attributes = await consumptionController.attributes.getLocalAttributes();
+
+        for (const attribute of attributes) {
+            await consumptionController.attributes.deleteAttribute(attribute);
+        }
+    });
+
+    test("runs all processor methods for a third party owned relationship attribute", async function () {
+        const thirdPartyOwnedRelationshipAttribute = await consumptionController.attributes.createAttributeUnsafe({
+            content: RelationshipAttribute.from({
+                key: "customerId",
+                value: {
+                    "@type": "ProprietaryString",
+                    value: "0815",
+                    title: "Customer ID"
+                },
+                owner: CoreAddress.from("thirdParty"),
+                confidentiality: RelationshipAttributeConfidentiality.Public
+            }),
+            shareInfo: {
+                peer: CoreAddress.from("peer"),
+                requestReference: CoreId.from("reqRef")
+            }
+        });
+
+        const notificationItem = PeerSharedAttributeDeletedByPeerNotificationItem.from({
+            attributeId: thirdPartyOwnedRelationshipAttribute.id
+        });
+        const notification = LocalNotification.from({
+            id: CoreId.from("notificationRef"),
+            source: LocalNotificationSource.from({
+                type: "Message",
+                reference: CoreId.from("messageRef")
+            }),
+            status: LocalNotificationStatus.Open,
+            isOwn: false,
+            peer: CoreAddress.from("peer"),
+            createdAt: CoreDate.utc(),
+            content: Notification.from({
+                id: CoreId.from("notificationRef"),
+                items: [notificationItem]
+            }),
+            receivedByDevice: CoreId.from("deviceId")
+        });
+        const processor = new ThirdPartyOwnedRelationshipAttributeDeletedByPeerNotificationItemProcessor(consumptionController);
+
+        /* Run and check validation. */
+        const checkResult = await processor.checkPrerequisitesOfIncomingNotificationItem(notificationItem, notification);
+        expect(checkResult.isError()).toBe(false);
+
+        /* Run process() and validate its results. */
+        const event = await processor.process(notificationItem, notification);
+        expect(event).toBeInstanceOf(ThirdPartyOwnedRelationshipAttributeDeletedByPeerEvent);
+        const updatedAttribute = event?.data;
+        expect(notificationItem.attributeId.equals(updatedAttribute!.id)).toBe(true);
+        expect(updatedAttribute!.deletionInfo?.deletionStatus).toStrictEqual(DeletionStatus.DeletedByPeer);
+
+        /* Manually trigger and verify rollback. */
+        await processor.rollback(notificationItem, notification);
+        const attributeAfterRollback = await consumptionController.attributes.getLocalAttribute(notificationItem.attributeId);
+        expect(attributeAfterRollback?.deletionInfo).toBeUndefined();
+    });
+
+    test("runs all processor methods for an unknown attribute", async function () {
+        const unknownAttributeId = CoreId.from("id1xxxxxxxxxxxxxxxxx");
+
+        const notificationItem = ThirdPartyOwnedRelationshipAttributeDeletedByPeerNotificationItem.from({
+            attributeId: unknownAttributeId
+        });
+        const notification = LocalNotification.from({
+            id: CoreId.from("notificationRef"),
+            source: LocalNotificationSource.from({
+                type: "Message",
+                reference: CoreId.from("messageRef")
+            }),
+            status: LocalNotificationStatus.Open,
+            isOwn: false,
+            peer: CoreAddress.from("peer"),
+            createdAt: CoreDate.utc(),
+            content: Notification.from({
+                id: CoreId.from("notificationRef"),
+                items: [notificationItem]
+            }),
+            receivedByDevice: CoreId.from("deviceId")
+        });
+        const processor = new ThirdPartyOwnedRelationshipAttributeDeletedByPeerNotificationItemProcessor(consumptionController);
+
+        /* Run and check validation. */
+        const checkResult = await processor.checkPrerequisitesOfIncomingNotificationItem(notificationItem, notification);
+        expect(checkResult.isError()).toBe(false);
+
+        /* Run process() and validate its results. */
+        const processResult = await processor.process(notificationItem, notification);
+        expect(processResult).toBeUndefined();
+
+        /* Manually trigger and verify rollback. */
+        const rollbackResult = await processor.rollback(notificationItem, notification);
+        expect(rollbackResult).toBeUndefined();
+    });
+
+    test("detects spoofing attempts", async function () {
+        /* A naughty peer is trying to delete attributes shared
+         * not with him, but with another peer. This must be
+         * caught by the validation. */
+        const differentThirdPartyOwnedRelationshipAttribute = await consumptionController.attributes.createAttributeUnsafe({
+            content: RelationshipAttribute.from({
+                key: "customerId",
+                value: {
+                    "@type": "ProprietaryString",
+                    value: "0815",
+                    title: "Customer ID"
+                },
+                owner: CoreAddress.from("thirdParty"),
+                confidentiality: RelationshipAttributeConfidentiality.Public
+            }),
+            shareInfo: {
+                peer: CoreAddress.from("otherPeer"),
+                requestReference: CoreId.from("reqRef")
+            }
+        });
+
+        const notificationItem = ThirdPartyOwnedRelationshipAttributeDeletedByPeerNotificationItem.from({
+            attributeId: differentThirdPartyOwnedRelationshipAttribute.id
+        });
+
+        const notification = LocalNotification.from({
+            id: CoreId.from("notificationRef"),
+            source: LocalNotificationSource.from({
+                type: "Message",
+                reference: CoreId.from("messageRef")
+            }),
+            status: LocalNotificationStatus.Open,
+            isOwn: false,
+            peer: CoreAddress.from("naughtyPeer"),
+            createdAt: CoreDate.utc(),
+            content: Notification.from({
+                id: CoreId.from("notificationRef"),
+                items: [notificationItem]
+            }),
+            receivedByDevice: CoreId.from("deviceId")
+        });
+        const processor = new ThirdPartyOwnedRelationshipAttributeDeletedByPeerNotificationItemProcessor(consumptionController);
+
+        const checkResult = await processor.checkPrerequisitesOfIncomingNotificationItem(notificationItem, notification);
+        expect(checkResult).errorValidationResult({
+            code: "error.consumption.attributes.senderIsNotPeerOfSharedAttribute"
+        });
+    });
+});

--- a/packages/consumption/test/modules/notifications/itemProcessors/attributeDeleted/ThirdPartyOwnedRelationshipAttributeDeletedByPeerNotificationItemProcessor.test.ts
+++ b/packages/consumption/test/modules/notifications/itemProcessors/attributeDeleted/ThirdPartyOwnedRelationshipAttributeDeletedByPeerNotificationItemProcessor.test.ts
@@ -148,9 +148,9 @@ describe("ThirdPartyOwnedRelationshipAttributeDeletedByPeerNotificationItemProce
 
     test("detects spoofing attempts", async function () {
         /* A naughty peer is trying to delete attributes shared
-         * not with him, but with another peer. This must be
+         * not with them, but with another peer. This must be
          * caught by the validation. */
-        const differentThirdPartyOwnedRelationshipAttribute = await consumptionController.attributes.createAttributeUnsafe({
+        const thirdPartyOwnedRelationshipAttributeSharedWithOtherPeer = await consumptionController.attributes.createAttributeUnsafe({
             content: RelationshipAttribute.from({
                 key: "customerId",
                 value: {
@@ -168,7 +168,7 @@ describe("ThirdPartyOwnedRelationshipAttributeDeletedByPeerNotificationItemProce
         });
 
         const notificationItem = ThirdPartyOwnedRelationshipAttributeDeletedByPeerNotificationItem.from({
-            attributeId: differentThirdPartyOwnedRelationshipAttribute.id
+            attributeId: thirdPartyOwnedRelationshipAttributeSharedWithOtherPeer.id
         });
 
         const notification = LocalNotification.from({

--- a/packages/content/src/notifications/items/ThirdPartyOwnedRelationshipAttributeDeletedByPeerNotificationItem.ts
+++ b/packages/content/src/notifications/items/ThirdPartyOwnedRelationshipAttributeDeletedByPeerNotificationItem.ts
@@ -1,0 +1,28 @@
+import { serialize, type, validate } from "@js-soft/ts-serval";
+import { CoreId, ICoreId } from "@nmshd/transport";
+import { INotificationItem, NotificationItem, NotificationItemJSON } from "../NotificationItem";
+
+export interface ThirdPartyOwnedRelationshipAttributeDeletedByPeerNotificationItemJSON extends NotificationItemJSON {
+    "@type": "ThirdPartyOwnedRelationshipAttributeDeletedByPeerNotificationItem";
+    attributeId: string;
+}
+
+export interface IThirdPartyOwnedRelationshipAttributeDeletedByPeerNotificationItem extends INotificationItem {
+    attributeId: ICoreId;
+}
+
+@type("ThirdPartyOwnedRelationshipAttributeDeletedByPeerNotificationItem")
+export class ThirdPartyOwnedRelationshipAttributeDeletedByPeerNotificationItem
+    extends NotificationItem
+    implements IThirdPartyOwnedRelationshipAttributeDeletedByPeerNotificationItem
+{
+    @validate()
+    @serialize()
+    public attributeId: CoreId;
+
+    public static from(
+        value: IThirdPartyOwnedRelationshipAttributeDeletedByPeerNotificationItem | Omit<ThirdPartyOwnedRelationshipAttributeDeletedByPeerNotificationItemJSON, "@type">
+    ): ThirdPartyOwnedRelationshipAttributeDeletedByPeerNotificationItem {
+        return this.fromAny(value);
+    }
+}

--- a/packages/content/src/notifications/items/index.ts
+++ b/packages/content/src/notifications/items/index.ts
@@ -1,3 +1,4 @@
 export * from "./OwnSharedAttributeDeletedByOwnerNotificationItem";
 export * from "./PeerSharedAttributeDeletedByPeerNotificationItem";
 export * from "./PeerSharedAttributeSucceededNotificationItem";
+export * from "./ThirdPartyOwnedRelationshipAttributeDeletedByPeerNotificationItem";

--- a/packages/runtime/src/events/EventProxy.ts
+++ b/packages/runtime/src/events/EventProxy.ts
@@ -16,7 +16,8 @@ import {
     OwnSharedAttributeSucceededEvent,
     PeerSharedAttributeDeletedByPeerEvent,
     PeerSharedAttributeSucceededEvent,
-    RepositoryAttributeSucceededEvent
+    RepositoryAttributeSucceededEvent,
+    ThirdPartyOwnedRelationshipAttributeDeletedByPeerEvent
 } from "./consumption";
 import {
     MessageDeliveredEvent,
@@ -78,12 +79,16 @@ export class EventProxy {
             this.targetEventBus.publish(new AttributeDeletedEvent(event.eventTargetAddress, AttributeMapper.toAttributeDTO(event.data)));
         });
 
+        this.subscribeToSourceEvent(consumption.OwnSharedAttributeDeletedByOwnerEvent, (event) => {
+            this.targetEventBus.publish(new OwnSharedAttributeDeletedByOwnerEvent(event.eventTargetAddress, AttributeMapper.toAttributeDTO(event.data)));
+        });
+
         this.subscribeToSourceEvent(consumption.PeerSharedAttributeDeletedByPeerEvent, (event) => {
             this.targetEventBus.publish(new PeerSharedAttributeDeletedByPeerEvent(event.eventTargetAddress, AttributeMapper.toAttributeDTO(event.data)));
         });
 
-        this.subscribeToSourceEvent(consumption.OwnSharedAttributeDeletedByOwnerEvent, (event) => {
-            this.targetEventBus.publish(new OwnSharedAttributeDeletedByOwnerEvent(event.eventTargetAddress, AttributeMapper.toAttributeDTO(event.data)));
+        this.subscribeToSourceEvent(consumption.ThirdPartyOwnedRelationshipAttributeDeletedByPeerEvent, (event) => {
+            this.targetEventBus.publish(new ThirdPartyOwnedRelationshipAttributeDeletedByPeerEvent(event.eventTargetAddress, AttributeMapper.toAttributeDTO(event.data)));
         });
 
         this.subscribeToSourceEvent(consumption.OwnSharedAttributeSucceededEvent, (event) => {

--- a/packages/runtime/src/events/consumption/ThirdPartyOwnedRelationshipAttributeDeletedByPeerEvent.ts
+++ b/packages/runtime/src/events/consumption/ThirdPartyOwnedRelationshipAttributeDeletedByPeerEvent.ts
@@ -1,0 +1,10 @@
+import { LocalAttributeDTO } from "../../types";
+import { DataEvent } from "../DataEvent";
+
+export class ThirdPartyOwnedRelationshipAttributeDeletedByPeerEvent extends DataEvent<LocalAttributeDTO> {
+    public static readonly namespace = "consumption.thirdPartyOwnedRelationshipAttributeDeletedByPeer";
+
+    public constructor(eventTargetAddress: string, data: LocalAttributeDTO) {
+        super(ThirdPartyOwnedRelationshipAttributeDeletedByPeerEvent.namespace, eventTargetAddress, data);
+    }
+}

--- a/packages/runtime/src/events/consumption/index.ts
+++ b/packages/runtime/src/events/consumption/index.ts
@@ -18,3 +18,4 @@ export * from "./RelationshipEvent";
 export * from "./RelationshipTemplateProcessedEvent";
 export * from "./RepositoryAttributeSucceededEvent";
 export * from "./SuccessionEventData";
+export * from "./ThirdPartyOwnedRelationshipAttributeDeletedByPeerEvent";

--- a/packages/runtime/src/extensibility/facades/consumption/AttributesFacade.ts
+++ b/packages/runtime/src/extensibility/facades/consumption/AttributesFacade.ts
@@ -75,7 +75,7 @@ export class AttributesFacade {
         @Inject private readonly notifyPeerAboutRepositoryAttributeSuccessionUseCase: NotifyPeerAboutRepositoryAttributeSuccessionUseCase,
         @Inject private readonly deleteOwnSharedAttributeAndNotifyPeerUseCase: DeleteOwnSharedAttributeAndNotifyPeerUseCase,
         @Inject private readonly deletePeerSharedAttributeAndNotifyOwnerUseCase: DeletePeerSharedAttributeAndNotifyOwnerUseCase,
-        @Inject private readonly deleteThirdPartyOwnedAttributeAndNotifyPeerUseCase: DeleteThirdPartyOwnedRelationshipAttributeAndNotifyPeerUseCase,
+        @Inject private readonly deleteThirdPartyOwnedRelationshipAttributeAndNotifyPeerUseCase: DeleteThirdPartyOwnedRelationshipAttributeAndNotifyPeerUseCase,
         @Inject private readonly deleteRepositoryAttributeUseCase: DeleteRepositoryAttributeUseCase
     ) {}
 
@@ -163,8 +163,8 @@ export class AttributesFacade {
         return await this.deletePeerSharedAttributeAndNotifyOwnerUseCase.execute(request);
     }
 
-    public async deleteThirdPartyOwnedAttributeAndNotifyPeer(request: DeleteThirdPartyOwnedRelationshipAttributeAndNotifyPeerRequest): Promise<Result<Notification>> {
-        return await this.deleteThirdPartyOwnedAttributeAndNotifyPeerUseCase.execute(request);
+    public async deleteThirdPartyOwnedRelationshipAttributeAndNotifyPeer(request: DeleteThirdPartyOwnedRelationshipAttributeAndNotifyPeerRequest): Promise<Result<Notification>> {
+        return await this.deleteThirdPartyOwnedRelationshipAttributeAndNotifyPeerUseCase.execute(request);
     }
 
     public async deleteRepositoryAttribute(request: DeleteRepositoryAttributeRequest): Promise<Result<void>> {

--- a/packages/runtime/src/extensibility/facades/consumption/AttributesFacade.ts
+++ b/packages/runtime/src/extensibility/facades/consumption/AttributesFacade.ts
@@ -13,6 +13,8 @@ import {
     DeletePeerSharedAttributeAndNotifyOwnerUseCase,
     DeleteRepositoryAttributeRequest,
     DeleteRepositoryAttributeUseCase,
+    DeleteThirdPartyOwnedRelationshipAttributeAndNotifyPeerRequest,
+    DeleteThirdPartyOwnedRelationshipAttributeAndNotifyPeerUseCase,
     ExecuteIdentityAttributeQueryRequest,
     ExecuteIdentityAttributeQueryUseCase,
     ExecuteIQLQueryRequest,
@@ -73,6 +75,7 @@ export class AttributesFacade {
         @Inject private readonly notifyPeerAboutRepositoryAttributeSuccessionUseCase: NotifyPeerAboutRepositoryAttributeSuccessionUseCase,
         @Inject private readonly deleteOwnSharedAttributeAndNotifyPeerUseCase: DeleteOwnSharedAttributeAndNotifyPeerUseCase,
         @Inject private readonly deletePeerSharedAttributeAndNotifyOwnerUseCase: DeletePeerSharedAttributeAndNotifyOwnerUseCase,
+        @Inject private readonly deleteThirdPartyOwnedAttributeAndNotifyPeerUseCase: DeleteThirdPartyOwnedRelationshipAttributeAndNotifyPeerUseCase,
         @Inject private readonly deleteRepositoryAttributeUseCase: DeleteRepositoryAttributeUseCase
     ) {}
 
@@ -158,6 +161,10 @@ export class AttributesFacade {
 
     public async deletePeerSharedAttributeAndNotifyOwner(request: DeletePeerSharedAttributeAndNotifyOwnerRequest): Promise<Result<Notification>> {
         return await this.deletePeerSharedAttributeAndNotifyOwnerUseCase.execute(request);
+    }
+
+    public async deleteThirdPartyOwnedAttributeAndNotifyPeer(request: DeleteThirdPartyOwnedRelationshipAttributeAndNotifyPeerRequest): Promise<Result<Notification>> {
+        return await this.deleteThirdPartyOwnedAttributeAndNotifyPeerUseCase.execute(request);
     }
 
     public async deleteRepositoryAttribute(request: DeleteRepositoryAttributeRequest): Promise<Result<void>> {

--- a/packages/runtime/src/useCases/common/RuntimeErrors.ts
+++ b/packages/runtime/src/useCases/common/RuntimeErrors.ts
@@ -181,8 +181,11 @@ class Attributes {
         return new ApplicationError("error.runtime.attributes.isNotPeerSharedAttribute", `Attribute '${attributeId.toString()}' is not a peer shared attribute.`);
     }
 
-    public isNotThirdPartyOwnedAttribute(attributeId: CoreId | string): ApplicationError {
-        return new ApplicationError("error.runtime.attributes.isNotThirdPartyOwnedAttribute", `Attribute '${attributeId.toString()}' is not a third party owned attribute.`);
+    public isNotThirdPartyOwnedRelationshipAttribute(attributeId: CoreId | string): ApplicationError {
+        return new ApplicationError(
+            "error.runtime.attributes.isNotThirdPartyOwnedRelationshipAttribute",
+            `Attribute '${attributeId.toString()}' is not a third party owned relationship attribute.`
+        );
     }
 }
 

--- a/packages/runtime/src/useCases/common/RuntimeErrors.ts
+++ b/packages/runtime/src/useCases/common/RuntimeErrors.ts
@@ -173,12 +173,16 @@ class Attributes {
         );
     }
 
+    public isNotOwnSharedAttribute(attributeId: CoreId | string): ApplicationError {
+        return new ApplicationError("error.runtime.attributes.isNotOwnSharedAttribute", `Attribute '${attributeId.toString()}' is not an own shared attribute.`);
+    }
+
     public isNotPeerSharedAttribute(attributeId: CoreId | string): ApplicationError {
         return new ApplicationError("error.runtime.attributes.isNotPeerSharedAttribute", `Attribute '${attributeId.toString()}' is not a peer shared attribute.`);
     }
 
-    public isNotOwnSharedAttribute(attributeId: CoreId | string): ApplicationError {
-        return new ApplicationError("error.runtime.attributes.isNotOwnSharedAttribute", `Attribute '${attributeId.toString()}' is not an own shared attribute.`);
+    public isNotThirdPartyOwnedAttribute(attributeId: CoreId | string): ApplicationError {
+        return new ApplicationError("error.runtime.attributes.isNotThirdPartyOwnedAttribute", `Attribute '${attributeId.toString()}' is not a third party owned attribute.`);
     }
 }
 

--- a/packages/runtime/src/useCases/common/Schemas.ts
+++ b/packages/runtime/src/useCases/common/Schemas.ts
@@ -15879,6 +15879,29 @@ export const DeleteRepositoryAttributeRequest: any = {
     }
 }
 
+export const DeleteThirdPartyOwnedRelationshipAttributeAndNotifyPeerRequest: any = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$ref": "#/definitions/DeleteThirdPartyOwnedRelationshipAttributeAndNotifyPeerRequest",
+    "definitions": {
+        "DeleteThirdPartyOwnedRelationshipAttributeAndNotifyPeerRequest": {
+            "type": "object",
+            "properties": {
+                "attributeId": {
+                    "$ref": "#/definitions/AttributeIdString"
+                }
+            },
+            "required": [
+                "attributeId"
+            ],
+            "additionalProperties": false
+        },
+        "AttributeIdString": {
+            "type": "string",
+            "pattern": "ATT[A-Za-z0-9]{17}"
+        }
+    }
+}
+
 export const ExecuteIdentityAttributeQueryRequest: any = {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$ref": "#/definitions/ExecuteIdentityAttributeQueryRequest",

--- a/packages/runtime/src/useCases/consumption/attributes/DeleteThirdPartyOwnedRelationshipAttributeAndNotifyPeer.ts
+++ b/packages/runtime/src/useCases/consumption/attributes/DeleteThirdPartyOwnedRelationshipAttributeAndNotifyPeer.ts
@@ -1,6 +1,6 @@
 import { Result } from "@js-soft/ts-utils";
 import { AttributesController, ConsumptionIds, LocalAttribute } from "@nmshd/consumption";
-import { Notification } from "@nmshd/content";
+import { Notification, ThirdPartyOwnedRelationshipAttributeDeletedByPeerNotificationItem } from "@nmshd/content";
 import { AccountController, CoreId, MessageController } from "@nmshd/transport";
 import { Inject } from "typescript-ioc";
 import { AttributeIdString, RuntimeErrors, SchemaRepository, SchemaValidator, UseCase } from "../../common";

--- a/packages/runtime/src/useCases/consumption/attributes/DeleteThirdPartyOwnedRelationshipAttributeAndNotifyPeer.ts
+++ b/packages/runtime/src/useCases/consumption/attributes/DeleteThirdPartyOwnedRelationshipAttributeAndNotifyPeer.ts
@@ -34,7 +34,7 @@ export class DeleteThirdPartyOwnedRelationshipAttributeAndNotifyPeerUseCase exte
         }
 
         if (!thirdPartyOwnedRelationshipAttribute.isThirdPartyOwnedAttribute(this.accountController.identity.address)) {
-            return Result.fail(RuntimeErrors.attributes.isNotThirdPartyOwnedAttribute(thirdPartyOwnedRelationshipAttributeId));
+            return Result.fail(RuntimeErrors.attributes.isNotThirdPartyOwnedRelationshipAttribute(thirdPartyOwnedRelationshipAttributeId));
         }
 
         const validationResult = await this.attributesController.validateFullAttributeDeletionProcess(thirdPartyOwnedRelationshipAttribute);

--- a/packages/runtime/src/useCases/consumption/attributes/DeleteThirdPartyOwnedRelationshipAttributeAndNotifyPeer.ts
+++ b/packages/runtime/src/useCases/consumption/attributes/DeleteThirdPartyOwnedRelationshipAttributeAndNotifyPeer.ts
@@ -1,0 +1,62 @@
+import { Result } from "@js-soft/ts-utils";
+import { AttributesController, ConsumptionIds, LocalAttribute } from "@nmshd/consumption";
+import { Notification } from "@nmshd/content";
+import { AccountController, CoreId, MessageController } from "@nmshd/transport";
+import { Inject } from "typescript-ioc";
+import { AttributeIdString, RuntimeErrors, SchemaRepository, SchemaValidator, UseCase } from "../../common";
+
+export interface DeleteThirdPartyOwnedRelationshipAttributeAndNotifyPeerRequest {
+    attributeId: AttributeIdString;
+}
+
+class Validator extends SchemaValidator<DeleteThirdPartyOwnedRelationshipAttributeAndNotifyPeerRequest> {
+    public constructor(@Inject schemaRepository: SchemaRepository) {
+        super(schemaRepository.getSchema("DeleteThirdPartyOwnedRelationshipAttributeAndNotifyPeerRequest"));
+    }
+}
+
+export class DeleteThirdPartyOwnedRelationshipAttributeAndNotifyPeerUseCase extends UseCase<DeleteThirdPartyOwnedRelationshipAttributeAndNotifyPeerRequest, Notification> {
+    public constructor(
+        @Inject private readonly attributesController: AttributesController,
+        @Inject private readonly accountController: AccountController,
+        @Inject private readonly messageController: MessageController,
+        @Inject validator: Validator
+    ) {
+        super(validator);
+    }
+
+    protected async executeInternal(request: DeleteThirdPartyOwnedRelationshipAttributeAndNotifyPeerRequest): Promise<Result<Notification>> {
+        const thirdPartyOwnedRelationshipAttributeId = CoreId.from(request.attributeId);
+        const thirdPartyOwnedRelationshipAttribute = await this.attributesController.getLocalAttribute(thirdPartyOwnedRelationshipAttributeId);
+
+        if (typeof thirdPartyOwnedRelationshipAttribute === "undefined") {
+            return Result.fail(RuntimeErrors.general.recordNotFound(LocalAttribute));
+        }
+
+        if (!thirdPartyOwnedRelationshipAttribute.isThirdPartyOwnedAttribute(this.accountController.identity.address)) {
+            return Result.fail(RuntimeErrors.attributes.isNotThirdPartyOwnedAttribute(thirdPartyOwnedRelationshipAttributeId));
+        }
+
+        const validationResult = await this.attributesController.validateFullAttributeDeletionProcess(thirdPartyOwnedRelationshipAttribute);
+        if (validationResult.isError()) {
+            return Result.fail(validationResult.error);
+        }
+
+        await this.attributesController.executeFullAttributeDeletionProcess(thirdPartyOwnedRelationshipAttribute);
+
+        const notificationId = await ConsumptionIds.notification.generate();
+        const notificationItem = ThirdPartyOwnedRelationshipAttributeDeletedByPeerNotificationItem.from({ attributeId: thirdPartyOwnedRelationshipAttributeId });
+        const notification = Notification.from({
+            id: notificationId,
+            items: [notificationItem]
+        });
+        await this.messageController.sendMessage({
+            recipients: [thirdPartyOwnedRelationshipAttribute.shareInfo.peer],
+            content: notification
+        });
+
+        await this.accountController.syncDatawallet();
+
+        return Result.ok(notification);
+    }
+}

--- a/packages/runtime/src/useCases/consumption/attributes/index.ts
+++ b/packages/runtime/src/useCases/consumption/attributes/index.ts
@@ -4,6 +4,7 @@ export * from "./CreateRepositoryAttribute";
 export * from "./DeleteOwnSharedAttributeAndNotifyPeer";
 export * from "./DeletePeerSharedAttributeAndNotifyOwner";
 export * from "./DeleteRepositoryAttribute";
+export * from "./DeleteThirdPartyOwnedRelationshipAttributeAndNotifyPeer";
 export * from "./ExecuteIdentityAttributeQuery";
 export * from "./ExecuteIQLQuery";
 export * from "./ExecuteRelationshipAttributeQuery";

--- a/packages/runtime/test/consumption/attributes.test.ts
+++ b/packages/runtime/test/consumption/attributes.test.ts
@@ -1767,10 +1767,10 @@ describe("DeleteAttributeUseCases", () => {
                 content: {
                     value: {
                         "@type": "ProprietaryString",
-                        value: "My amazing string",
-                        title: "Nothing is this amazing"
+                        value: "A proprietary string",
+                        title: "A title"
                     },
-                    key: "amazing",
+                    key: "A key",
                     confidentiality: RelationshipAttributeConfidentiality.Public
                 }
             });
@@ -1780,7 +1780,7 @@ describe("DeleteAttributeUseCases", () => {
                 content: {
                     items: [
                         ReadAttributeRequestItem.from({
-                            query: ThirdPartyRelationshipAttributeQuery.from({ key: "amazing", owner: services3.address, thirdParty: [services3.address] }),
+                            query: ThirdPartyRelationshipAttributeQuery.from({ key: "A key", owner: services3.address, thirdParty: [services3.address] }),
                             mustBeAccepted: true
                         }).toJSON()
                     ]
@@ -1795,7 +1795,7 @@ describe("DeleteAttributeUseCases", () => {
             );
         });
 
-        test("should delete a third party owned RelationshipAttribute as the sender", async () => {
+        test("should delete a third party owned RelationshipAttribute as the sender of it", async () => {
             const senderThirdPartyOwnedRelationshipAttribute = (await services1.consumption.attributes.getAttribute({ id: thirdPartyOwnedRelationshipAttribute.id })).value;
             expect(senderThirdPartyOwnedRelationshipAttribute).toBeDefined();
 
@@ -1808,7 +1808,7 @@ describe("DeleteAttributeUseCases", () => {
             expect(getDeletedAttributeResult).toBeAnError(/.*/, "error.runtime.recordNotFound");
         });
 
-        test("should delete a third party owned RelationshipAttribute as the recipient", async () => {
+        test("should delete a third party owned RelationshipAttribute as the recipient of it", async () => {
             const recipientThirdPartyOwnedRelationshipAttribute = (await services2.consumption.attributes.getAttribute({ id: thirdPartyOwnedRelationshipAttribute.id })).value;
             expect(recipientThirdPartyOwnedRelationshipAttribute).toBeDefined();
 
@@ -1821,7 +1821,7 @@ describe("DeleteAttributeUseCases", () => {
             expect(getDeletedAttributeResult).toBeAnError(/.*/, "error.runtime.recordNotFound");
         });
 
-        test("should notify about third party owned RelationshipAttribute as the sender", async () => {
+        test("should notify about third party owned RelationshipAttribute as the sender of it", async () => {
             const notification = (
                 await services1.consumption.attributes.deleteThirdPartyOwnedRelationshipAttributeAndNotifyPeer({ attributeId: thirdPartyOwnedRelationshipAttribute.id })
             ).value;
@@ -1840,7 +1840,7 @@ describe("DeleteAttributeUseCases", () => {
             expect(CoreDate.from(updatedAttribute.deletionInfo!.deletionDate).isBetween(timeBeforeUpdate, timeAfterUpdate.add(1))).toBe(true);
         });
 
-        test("should notify about third party owned RelationshipAttribute as the recipient", async () => {
+        test("should notify about third party owned RelationshipAttribute as the recipient of it", async () => {
             const notification = (
                 await services2.consumption.attributes.deleteThirdPartyOwnedRelationshipAttributeAndNotifyPeer({ attributeId: thirdPartyOwnedRelationshipAttribute.id })
             ).value;

--- a/packages/runtime/test/consumption/attributes.test.ts
+++ b/packages/runtime/test/consumption/attributes.test.ts
@@ -20,6 +20,7 @@ import {
     DeleteOwnSharedAttributeAndNotifyPeerUseCase,
     DeletePeerSharedAttributeAndNotifyOwnerUseCase,
     DeleteRepositoryAttributeUseCase,
+    DeleteThirdPartyOwnedRelationshipAttributeAndNotifyPeerUseCase,
     ExecuteIdentityAttributeQueryUseCase,
     ExecuteRelationshipAttributeQueryUseCase,
     GetAttributesUseCase,
@@ -38,7 +39,8 @@ import {
     ShareRepositoryAttributeUseCase,
     SucceedRelationshipAttributeAndNotifyPeerUseCase,
     SucceedRepositoryAttributeRequest,
-    SucceedRepositoryAttributeUseCase
+    SucceedRepositoryAttributeUseCase,
+    ThirdPartyOwnedRelationshipAttributeDeletedByPeerEvent
 } from "../../src";
 import {
     acceptIncomingShareAttributeRequest,
@@ -1671,7 +1673,7 @@ describe("DeleteAttributeUseCases", () => {
             expect(getDeletedPredecessorResult).toBeAnError(/.*/, "error.runtime.recordNotFound");
         });
 
-        test("should remove 'shareInfo.sourceAttribute' from peer shared third party relationship attribute copies of a deleted repository attribute", async () => {
+        test("should remove 'shareInfo.sourceAttribute' from third party relationship attribute copies of a deleted relationship attribute", async () => {
             const peerSharedRelationshipAttribute = await executeFullCreateAndShareRelationshipAttributeFlow(services3, services1, {
                 content: {
                     value: {
@@ -1696,7 +1698,7 @@ describe("DeleteAttributeUseCases", () => {
                 }
             };
 
-            const peerSharedThirdPartyRelationshipAttribute = await executeFullRequestAndShareThirdPartyRelationshipAttributeFlow(
+            const thirdPartyOwnedRelationshipAttribute = await executeFullRequestAndShareThirdPartyRelationshipAttributeFlow(
                 services1,
                 services2,
                 requestParams,
@@ -1705,13 +1707,13 @@ describe("DeleteAttributeUseCases", () => {
 
             await services1.consumption.attributes.deletePeerSharedAttributeAndNotifyOwner({ attributeId: peerSharedRelationshipAttribute.id });
 
-            const updatedPeerSharedThirdPartyRelationshipAttributeResult = await services1.consumption.attributes.getAttribute({
-                id: peerSharedThirdPartyRelationshipAttribute.id
+            const updatedThirdPartyOwnedRelationshipAttributeResult = await services1.consumption.attributes.getAttribute({
+                id: thirdPartyOwnedRelationshipAttribute.id
             });
-            expect(updatedPeerSharedThirdPartyRelationshipAttributeResult.isSuccess).toBe(true);
-            const updatedPeerSharedThirdPartyRelationshipAttribute = updatedPeerSharedThirdPartyRelationshipAttributeResult.value;
-            expect(updatedPeerSharedThirdPartyRelationshipAttribute.shareInfo).toBeDefined();
-            expect(updatedPeerSharedThirdPartyRelationshipAttribute.shareInfo!.sourceAttribute).toBeUndefined();
+            expect(updatedThirdPartyOwnedRelationshipAttributeResult.isSuccess).toBe(true);
+            const updatedThirdPartyOwnedRelationshipAttribute = updatedThirdPartyOwnedRelationshipAttributeResult.value;
+            expect(updatedThirdPartyOwnedRelationshipAttribute.shareInfo).toBeDefined();
+            expect(updatedThirdPartyOwnedRelationshipAttribute.shareInfo!.sourceAttribute).toBeUndefined();
         });
 
         test("should set the 'succeeds' property of the peer shared identity attribute successor to undefined", async () => {
@@ -1754,6 +1756,107 @@ describe("DeleteAttributeUseCases", () => {
             const updatedPredecessor = (await services1.consumption.attributes.getAttribute({ id: ownSharedIdentityAttributeVersion0.id })).value;
             expect(updatedPredecessor.deletionInfo?.deletionStatus).toStrictEqual(DeletionStatus.DeletedByPeer);
             expect(CoreDate.from(updatedPredecessor.deletionInfo!.deletionDate).isBetween(timeBeforeUpdate, timeAfterUpdate.add(1))).toBe(true);
+        });
+    });
+
+    describe(DeleteThirdPartyOwnedRelationshipAttributeAndNotifyPeerUseCase.name, () => {
+        let peerSharedRelationshipAttribute: LocalAttributeDTO;
+        let thirdPartyOwnedRelationshipAttribute: LocalAttributeDTO;
+        beforeEach(async () => {
+            peerSharedRelationshipAttribute = await executeFullCreateAndShareRelationshipAttributeFlow(services3, services1, {
+                content: {
+                    value: {
+                        "@type": "ProprietaryString",
+                        value: "My amazing string",
+                        title: "Nothing is this amazing"
+                    },
+                    key: "amazing",
+                    confidentiality: RelationshipAttributeConfidentiality.Public
+                }
+            });
+
+            const requestParams = {
+                peer: services1.address,
+                content: {
+                    items: [
+                        ReadAttributeRequestItem.from({
+                            query: ThirdPartyRelationshipAttributeQuery.from({ key: "amazing", owner: services3.address, thirdParty: [services3.address] }),
+                            mustBeAccepted: true
+                        }).toJSON()
+                    ]
+                }
+            };
+
+            thirdPartyOwnedRelationshipAttribute = await executeFullRequestAndShareThirdPartyRelationshipAttributeFlow(
+                services1,
+                services2,
+                requestParams,
+                peerSharedRelationshipAttribute.id
+            );
+        });
+
+        test("should delete a third party owned RelationshipAttribute as the sender", async () => {
+            const senderThirdPartyOwnedRelationshipAttribute = (await services1.consumption.attributes.getAttribute({ id: thirdPartyOwnedRelationshipAttribute.id })).value;
+            expect(senderThirdPartyOwnedRelationshipAttribute).toBeDefined();
+
+            const deletionResult = await services1.consumption.attributes.deleteThirdPartyOwnedRelationshipAttributeAndNotifyPeer({
+                attributeId: senderThirdPartyOwnedRelationshipAttribute.id
+            });
+            expect(deletionResult.isSuccess).toBe(true);
+
+            const getDeletedAttributeResult = await services1.consumption.attributes.getAttribute({ id: senderThirdPartyOwnedRelationshipAttribute.id });
+            expect(getDeletedAttributeResult).toBeAnError(/.*/, "error.runtime.recordNotFound");
+        });
+
+        test("should delete a third party owned RelationshipAttribute as the recipient", async () => {
+            const recipientThirdPartyOwnedRelationshipAttribute = (await services2.consumption.attributes.getAttribute({ id: thirdPartyOwnedRelationshipAttribute.id })).value;
+            expect(recipientThirdPartyOwnedRelationshipAttribute).toBeDefined();
+
+            const deletionResult = await services2.consumption.attributes.deleteThirdPartyOwnedRelationshipAttributeAndNotifyPeer({
+                attributeId: recipientThirdPartyOwnedRelationshipAttribute.id
+            });
+            expect(deletionResult.isSuccess).toBe(true);
+
+            const getDeletedAttributeResult = await services2.consumption.attributes.getAttribute({ id: recipientThirdPartyOwnedRelationshipAttribute.id });
+            expect(getDeletedAttributeResult).toBeAnError(/.*/, "error.runtime.recordNotFound");
+        });
+
+        test("should notify about third party owned RelationshipAttribute as the sender", async () => {
+            const notification = (
+                await services1.consumption.attributes.deleteThirdPartyOwnedRelationshipAttributeAndNotifyPeer({ attributeId: thirdPartyOwnedRelationshipAttribute.id })
+            ).value;
+            const timeBeforeUpdate = CoreDate.utc();
+            await syncUntilHasMessageWithNotification(services2.transport, notification.id);
+            await services2.eventBus.waitForEvent(ThirdPartyOwnedRelationshipAttributeDeletedByPeerEvent, (e) => {
+                return e.data.id.toString() === thirdPartyOwnedRelationshipAttribute.id;
+            });
+
+            const timeAfterUpdate = CoreDate.utc();
+
+            const result = await services2.consumption.attributes.getAttribute({ id: thirdPartyOwnedRelationshipAttribute.id });
+            expect(result.isSuccess).toBe(true);
+            const updatedAttribute = result.value;
+            expect(updatedAttribute.deletionInfo?.deletionStatus).toStrictEqual(DeletionStatus.DeletedByPeer);
+            expect(CoreDate.from(updatedAttribute.deletionInfo!.deletionDate).isBetween(timeBeforeUpdate, timeAfterUpdate.add(1))).toBe(true);
+        });
+
+        test("should notify about third party owned RelationshipAttribute as the recipient", async () => {
+            const notification = (
+                await services2.consumption.attributes.deleteThirdPartyOwnedRelationshipAttributeAndNotifyPeer({ attributeId: thirdPartyOwnedRelationshipAttribute.id })
+            ).value;
+            const timeBeforeUpdate = CoreDate.utc();
+            await syncUntilHasMessageWithNotification(services1.transport, notification.id);
+            await services1.eventBus.waitForEvent(ThirdPartyOwnedRelationshipAttributeDeletedByPeerEvent, (e) => {
+                return e.data.id.toString() === thirdPartyOwnedRelationshipAttribute.id;
+            });
+
+            const timeAfterUpdate = CoreDate.utc();
+
+            const result = await services1.consumption.attributes.getAttribute({ id: thirdPartyOwnedRelationshipAttribute.id });
+            expect(result.isSuccess).toBe(true);
+            const updatedAttribute = result.value;
+            expect(updatedAttribute.deletionInfo?.deletionStatus).toStrictEqual(DeletionStatus.DeletedByPeer);
+            expect(CoreDate.from(updatedAttribute.deletionInfo!.deletionDate).isBetween(timeBeforeUpdate, timeAfterUpdate.add(1))).toBe(true);
         });
     });
 });


### PR DESCRIPTION
The thirdPartyOwned adjustments in the LocalAttribute were copied from #76 .
The ThirdPartyOwnedRelationshipAttributeDeletedByPeerNotificationItemProcessor does the same like the PeerSharedAttributeDeletedByPeerNotificationItemProcessor, but @britsta and I discussed that it still makes sense to have a dedicated ThirdPartyOwnedRelationshipAttributeDeletedByPeerNotificationItem, to be more precise and consistent with the naming (which will also be applied in the documentation), and to be flexible if we want to adjust the handling of the deletion of PeerSharedAttributes compared to ThirdPartyOwnedRelationshipAttributes.