### PR TITLE
Fix/Add identityDeletionProcesses to ExternalEventReceivedEvent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12264,7 +12264,7 @@
         },
         "packages/app-runtime": {
             "name": "@nmshd/app-runtime",
-            "version": "3.2.0",
+            "version": "3.2.1",
             "license": "MIT",
             "dependencies": {
                 "@js-soft/docdb-access-loki": "^1.1.0",

--- a/packages/app-runtime/package.json
+++ b/packages/app-runtime/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nmshd/app-runtime",
-    "version": "3.2.0",
+    "version": "3.2.1",
     "description": "The App Runtime",
     "homepage": "https://enmeshed.eu",
     "repository": {

--- a/packages/app-runtime/src/events/ExternalEventReceivedEvent.ts
+++ b/packages/app-runtime/src/events/ExternalEventReceivedEvent.ts
@@ -1,15 +1,9 @@
-import { DataEvent, MessageDTO, RelationshipDTO } from "@nmshd/runtime";
+import { DataEvent, SyncEverythingResponse } from "@nmshd/runtime";
 
-export class ExternalEventReceivedEvent extends DataEvent<{
-    messages: MessageDTO[];
-    relationships: RelationshipDTO[];
-}> {
+export class ExternalEventReceivedEvent extends DataEvent<SyncEverythingResponse> {
     public static readonly namespace: string = "app.externalEventReceived";
 
-    public constructor(address: string, messages: MessageDTO[], relationships: RelationshipDTO[]) {
-        super(ExternalEventReceivedEvent.namespace, address, {
-            messages,
-            relationships
-        });
+    public constructor(address: string, syncEverythingResponse: SyncEverythingResponse) {
+        super(ExternalEventReceivedEvent.namespace, address, syncEverythingResponse);
     }
 }

--- a/packages/app-runtime/src/modules/pushNotifications/PushNotificationModule.ts
+++ b/packages/app-runtime/src/modules/pushNotifications/PushNotificationModule.ts
@@ -42,7 +42,7 @@ export class PushNotificationModule extends AppRuntimeModule<PushNotificationMod
                         return;
                     }
 
-                    this.runtime.eventBus.publish(new ExternalEventReceivedEvent(content.accRef, syncResult.value.messages, syncResult.value.relationships));
+                    this.runtime.eventBus.publish(new ExternalEventReceivedEvent(content.accRef, syncResult.value));
 
                     break;
                 default:

--- a/packages/runtime/src/useCases/common/Schemas.ts
+++ b/packages/runtime/src/useCases/common/Schemas.ts
@@ -20097,6 +20097,29 @@ export const SyncDatawalletRequest: any = {
     }
 }
 
+export const GetIdentityDeletionProcessRequest: any = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$ref": "#/definitions/GetIdentityDeletionProcessRequest",
+    "definitions": {
+        "GetIdentityDeletionProcessRequest": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "$ref": "#/definitions/IdentityDeletionProcessIdString"
+                }
+            },
+            "required": [
+                "id"
+            ],
+            "additionalProperties": false
+        },
+        "IdentityDeletionProcessIdString": {
+            "type": "string",
+            "pattern": "IDP[A-Za-z0-9]{17}"
+        }
+    }
+}
+
 export const DownloadAttachmentRequest: any = {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$ref": "#/definitions/DownloadAttachmentRequest",
@@ -21066,26 +21089,6 @@ export const CheckIdentityRequest: any = {
         "AddressString": {
             "type": "string",
             "pattern": "id1[A-Za-z0-9]{32,33}"
-        }
-    }
-}
-
-export const GetIdentityDeletionProcessRequest: any = {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "$ref": "#/definitions/GetIdentityDeletionProcessRequest",
-    "definitions": {
-        "GetIdentityDeletionProcessRequest": {
-            "type": "object",
-            "properties": {
-                "id": {
-                    "$ref": "#/definitions/IdentityDeletionProcessIdString"
-                }
-            },
-            "additionalProperties": false
-        },
-        "IdentityDeletionProcessIdString": {
-            "type": "string",
-            "pattern": "IDP[A-Za-z0-9]{17}"
         }
     }
 }


### PR DESCRIPTION
I used `SyncEverythingResponse` instead of manually adding `identityDeletionProcesses` in order to improve type safety for the future.