### PR TITLE
Ci/XSRF token being retrieved without the API key makes it invalid for subsequent calls

### DIFF
--- a/packages/runtime/test/lib/AdminApiClient.ts
+++ b/packages/runtime/test/lib/AdminApiClient.ts
@@ -12,9 +12,8 @@ export async function getBackboneAdminApiClient(): Promise<Axios> {
     if (!adminAPIBaseUrl) throw new Error("Missing environment variable NMSHD_TEST_BASEURL_ADMIN_API");
     const csrf = await axios.get(`${adminAPIBaseUrl}/api/v1/xsrf`, {
         headers: {
-            /* eslint-disable @typescript-eslint/naming-convention */
+            /* eslint-disable-next-line @typescript-eslint/naming-convention */
             "x-api-key": process.env.NMSHD_TEST_ADMIN_API_KEY!
-            /* eslint-enable @typescript-eslint/naming-convention */
         }
     });
     adminClient = axios.create({

--- a/packages/runtime/test/lib/AdminApiClient.ts
+++ b/packages/runtime/test/lib/AdminApiClient.ts
@@ -12,7 +12,9 @@ export async function getBackboneAdminApiClient(): Promise<Axios> {
     if (!adminAPIBaseUrl) throw new Error("Missing environment variable NMSHD_TEST_BASEURL_ADMIN_API");
     const csrf = await axios.get(`${adminAPIBaseUrl}/api/v1/xsrf`, {
         headers: {
+            /* eslint-disable @typescript-eslint/naming-convention */
             "x-api-key": process.env.NMSHD_TEST_ADMIN_API_KEY!
+            /* eslint-enable @typescript-eslint/naming-convention */
         }
     });
     adminClient = axios.create({

--- a/packages/runtime/test/lib/AdminApiClient.ts
+++ b/packages/runtime/test/lib/AdminApiClient.ts
@@ -10,7 +10,11 @@ export async function getBackboneAdminApiClient(): Promise<Axios> {
 
     const adminAPIBaseUrl = process.env.NMSHD_TEST_BASEURL_ADMIN_API!;
     if (!adminAPIBaseUrl) throw new Error("Missing environment variable NMSHD_TEST_BASEURL_ADMIN_API");
-    const csrf = await axios.get(`${adminAPIBaseUrl}/api/v1/xsrf`);
+    const csrf = await axios.get(`${adminAPIBaseUrl}/api/v1/xsrf`, {
+        headers: {
+            "x-api-key": process.env.NMSHD_TEST_ADMIN_API_KEY!
+        }
+    });
     adminClient = axios.create({
         baseURL: adminAPIBaseUrl,
         headers: {

--- a/packages/transport/test/testHelpers/AdminApiClient.ts
+++ b/packages/transport/test/testHelpers/AdminApiClient.ts
@@ -13,7 +13,9 @@ export class AdminApiClient {
         if (!adminAPIBaseUrl) throw new Error("Missing environment variable NMSHD_TEST_BASEURL_ADMIN_API");
         const csrf = await axios.get(`${adminAPIBaseUrl}/api/v1/xsrf`, {
             headers: {
+                /* eslint-disable @typescript-eslint/naming-convention */
                 "x-api-key": process.env.NMSHD_TEST_ADMIN_API_KEY!
+                /* eslint-enable @typescript-eslint/naming-convention */
             }
         });
 

--- a/packages/transport/test/testHelpers/AdminApiClient.ts
+++ b/packages/transport/test/testHelpers/AdminApiClient.ts
@@ -11,7 +11,12 @@ export class AdminApiClient {
         }
         const adminAPIBaseUrl = process.env.NMSHD_TEST_BASEURL_ADMIN_API;
         if (!adminAPIBaseUrl) throw new Error("Missing environment variable NMSHD_TEST_BASEURL_ADMIN_API");
-        const csrf = await axios.get(`${adminAPIBaseUrl}/api/v1/xsrf`);
+        const csrf = await axios.get(`${adminAPIBaseUrl}/api/v1/xsrf`, {
+            headers: {
+                "x-api-key": process.env.NMSHD_TEST_ADMIN_API_KEY!
+            }
+        });
+
         AdminApiClient.adminClient = axios.create({
             baseURL: adminAPIBaseUrl,
             headers: {

--- a/packages/transport/test/testHelpers/AdminApiClient.ts
+++ b/packages/transport/test/testHelpers/AdminApiClient.ts
@@ -13,9 +13,8 @@ export class AdminApiClient {
         if (!adminAPIBaseUrl) throw new Error("Missing environment variable NMSHD_TEST_BASEURL_ADMIN_API");
         const csrf = await axios.get(`${adminAPIBaseUrl}/api/v1/xsrf`, {
             headers: {
-                /* eslint-disable @typescript-eslint/naming-convention */
+                /* eslint-disable-next-line @typescript-eslint/naming-convention */
                 "x-api-key": process.env.NMSHD_TEST_ADMIN_API_KEY!
-                /* eslint-enable @typescript-eslint/naming-convention */
             }
         });
 


### PR DESCRIPTION
As the subsequent calls carry the API key, this results in a claims-based user mismatch.

This PR fixes the current behaviour.

Btw, I'm not sure why there are two files, but I fixed both anyway.