### PR TITLE
Fix/SharedToPeerDVO without sourceAttribute

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12332,7 +12332,7 @@
         },
         "packages/runtime": {
             "name": "@nmshd/runtime",
-            "version": "4.8.0",
+            "version": "4.8.1",
             "license": "MIT",
             "dependencies": {
                 "@js-soft/docdb-querytranslator": "^1.1.4",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nmshd/runtime",
-    "version": "4.8.0",
+    "version": "4.8.1",
     "description": "The enmeshed client runtime.",
     "homepage": "https://enmeshed.eu",
     "repository": {

--- a/packages/runtime/src/dataViews/DataViewExpander.ts
+++ b/packages/runtime/src/dataViews/DataViewExpander.ts
@@ -1082,10 +1082,10 @@ export class DataViewExpander {
             }
             const identityAttribute = localAttribute.content;
 
-            if (localAttribute.shareInfo.sourceAttribute) {
-                // Own Shared Attribute
+            if (identityAttribute.owner === localAttribute.shareInfo.peer) {
+                // Peer Attribute
                 return {
-                    type: "SharedToPeerAttributeDVO",
+                    type: "PeerAttributeDVO",
                     id: attribute.id,
                     name,
                     description,
@@ -1097,22 +1097,20 @@ export class DataViewExpander {
                     valueHints,
                     isValid: true,
                     createdAt: attribute.createdAt,
-                    isOwn: true,
+                    isOwn: false,
                     peer: peer,
                     isDraft: false,
                     requestReference: localAttribute.shareInfo.requestReference?.toString(),
                     notificationReference: localAttribute.shareInfo.notificationReference?.toString(),
-                    sourceAttribute: localAttribute.shareInfo.sourceAttribute.toString(),
                     tags: identityAttribute.tags ? identityAttribute.tags : [],
                     valueType,
                     deletionStatus: localAttribute.deletionInfo?.deletionStatus,
                     deletionDate: localAttribute.deletionInfo?.deletionDate.toString()
                 };
             }
-
-            // Peer Attribute
+            // Own Shared Attribute
             return {
-                type: "PeerAttributeDVO",
+                type: "SharedToPeerAttributeDVO",
                 id: attribute.id,
                 name,
                 description,
@@ -1124,11 +1122,12 @@ export class DataViewExpander {
                 valueHints,
                 isValid: true,
                 createdAt: attribute.createdAt,
-                isOwn: false,
+                isOwn: true,
                 peer: peer,
                 isDraft: false,
                 requestReference: localAttribute.shareInfo.requestReference?.toString(),
                 notificationReference: localAttribute.shareInfo.notificationReference?.toString(),
+                sourceAttribute: localAttribute.shareInfo.sourceAttribute?.toString(),
                 tags: identityAttribute.tags ? identityAttribute.tags : [],
                 valueType,
                 deletionStatus: localAttribute.deletionInfo?.deletionStatus,

--- a/packages/runtime/src/dataViews/DataViewExpander.ts
+++ b/packages/runtime/src/dataViews/DataViewExpander.ts
@@ -1026,7 +1026,7 @@ export class DataViewExpander {
                 }
 
                 // Peer Relationship Attribute
-                if (relationshipAttribute.owner === localAttribute.shareInfo.peer) {
+                if (relationshipAttribute.owner.toString() === peer) {
                     return {
                         type: "PeerRelationshipAttributeDVO",
                         id: attribute.id,
@@ -1082,7 +1082,7 @@ export class DataViewExpander {
             }
             const identityAttribute = localAttribute.content;
 
-            if (identityAttribute.owner === localAttribute.shareInfo.peer) {
+            if (identityAttribute.owner.toString() === peer) {
                 // Peer Attribute
                 return {
                     type: "PeerAttributeDVO",

--- a/packages/runtime/src/dataViews/consumption/LocalAttributeDVO.ts
+++ b/packages/runtime/src/dataViews/consumption/LocalAttributeDVO.ts
@@ -44,7 +44,7 @@ export interface SharedToPeerAttributeDVO extends LocalAttributeDVO {
     peer: string; // Careful: We cannot expand the peer to an IdentityDVO, as the IdentityDVO possibly contains the LocalAttributesDVO of the Relationship (endless recursion)
     requestReference?: string;
     notificationReference?: string;
-    sourceAttribute: string;
+    sourceAttribute?: string;
     isOwn: true;
     tags: string[];
     deletionDate?: string;


### PR DESCRIPTION
If a RepositoryAttribute is deleted, the shareInfo.sourceAttribute property of its own shared IdentityAttributes is set to undefined. Thus, we cannot classify own shared IdentityAttributes by this property. Instead, we must check if the Attribute owner and shareInfo.peer match, in order to know whether the IdentityAttribute is own shared or peer shared. 

Currently, own shared IdentityAttributes are incorrectly expanded to PeerAttributeDVOs instead of SharedToPeerAttributeDVOs. This poses a problem for the implementation of Attribute deletion in the App.