### PR TITLE
fix/pin ts-json-schema-generator version to avoid build errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12362,7 +12362,7 @@
                 "@types/lodash": "^4.17.4",
                 "@types/luxon": "^3.4.2",
                 "@types/qrcode": "^1.5.5",
-                "ts-json-schema-generator": "^2.1.1"
+                "ts-json-schema-generator": "2.1.1"
             }
         },
         "packages/runtime/node_modules/ajv": {

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -79,7 +79,7 @@
         "@types/lodash": "^4.17.4",
         "@types/luxon": "^3.4.2",
         "@types/qrcode": "^1.5.5",
-        "ts-json-schema-generator": "^2.1.1"
+        "ts-json-schema-generator": "2.1.1"
     },
     "publishConfig": {
         "access": "public",


### PR DESCRIPTION
Version 2.2.0 would nor build due to error.
https://github.com/vega/ts-json-schema-generator/issues/1967#issuecomment-2131409014

This is already fixed in 2.3.0 prerelease.