### PR TITLE
Feature/Make tags optional for LocalAttributeDVOs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12332,7 +12332,7 @@
         },
         "packages/runtime": {
             "name": "@nmshd/runtime",
-            "version": "4.9.0",
+            "version": "4.9.1",
             "license": "MIT",
             "dependencies": {
                 "@js-soft/docdb-querytranslator": "^1.1.4",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nmshd/runtime",
-    "version": "4.9.0",
+    "version": "4.9.1",
     "description": "The enmeshed client runtime.",
     "homepage": "https://enmeshed.eu",
     "repository": {

--- a/packages/runtime/src/dataViews/DataViewExpander.ts
+++ b/packages/runtime/src/dataViews/DataViewExpander.ts
@@ -1142,7 +1142,7 @@ export class DataViewExpander {
                     isDraft: false,
                     requestReference: localAttribute.shareInfo.requestReference?.toString(),
                     notificationReference: localAttribute.shareInfo.notificationReference?.toString(),
-                    tags: identityAttribute.tags ? identityAttribute.tags : [],
+                    tags: identityAttribute.tags,
                     valueType,
                     deletionStatus: localAttribute.deletionInfo?.deletionStatus,
                     deletionDate: localAttribute.deletionInfo?.deletionDate.toString()
@@ -1168,7 +1168,7 @@ export class DataViewExpander {
                 requestReference: localAttribute.shareInfo.requestReference?.toString(),
                 notificationReference: localAttribute.shareInfo.notificationReference?.toString(),
                 sourceAttribute: localAttribute.shareInfo.sourceAttribute?.toString(),
-                tags: identityAttribute.tags ? identityAttribute.tags : [],
+                tags: identityAttribute.tags,
                 valueType,
                 deletionStatus: localAttribute.deletionInfo?.deletionStatus,
                 deletionDate: localAttribute.deletionInfo?.deletionDate.toString()
@@ -1196,7 +1196,7 @@ export class DataViewExpander {
             isOwn: true,
             isDraft: false,
             sharedWith: sharedToPeerDVOs as SharedToPeerAttributeDVO[],
-            tags: identityAttribute.tags ? identityAttribute.tags : [],
+            tags: identityAttribute.tags,
             valueType
         };
     }

--- a/packages/runtime/src/dataViews/consumption/LocalAttributeDVO.ts
+++ b/packages/runtime/src/dataViews/consumption/LocalAttributeDVO.ts
@@ -33,7 +33,7 @@ export interface RepositoryAttributeDVO extends LocalAttributeDVO {
     type: "RepositoryAttributeDVO";
     sharedWith: SharedToPeerAttributeDVO[];
     isOwn: true;
-    tags: string[];
+    tags?: string[];
 }
 
 /**
@@ -46,7 +46,7 @@ export interface SharedToPeerAttributeDVO extends LocalAttributeDVO {
     notificationReference?: string;
     sourceAttribute?: string;
     isOwn: true;
-    tags: string[];
+    tags?: string[];
     deletionDate?: string;
     deletionStatus?: string;
 }
@@ -60,7 +60,7 @@ export interface PeerAttributeDVO extends LocalAttributeDVO {
     requestReference?: string;
     notificationReference?: string;
     isOwn: false;
-    tags: string[];
+    tags?: string[];
     deletionDate?: string;
     deletionStatus?: string;
 }

--- a/packages/runtime/test/dataViews/IQLQueryExpanded.test.ts
+++ b/packages/runtime/test/dataViews/IQLQueryExpanded.test.ts
@@ -103,7 +103,7 @@ describe("IQLQueryExpanded", () => {
         const givenName = dvo.value as AbstractStringJSON;
         expect(givenName["@type"]).toBe("GivenName");
         expect(givenName.value).toBe("Hugo");
-        expect(dvo.tags[0]).toBe("default");
+        expect(dvo.tags![0]).toBe("default");
         expect(dvo.createdAt).toStrictEqual(attribute.createdAt);
         expect(dvo.isOwn).toBe(true);
         expect(dvo.isValid).toBe(true);
@@ -150,7 +150,7 @@ describe("IQLQueryExpanded", () => {
         const value3 = dvo.value as AbstractStringJSON;
         expect(value3["@type"]).toBe("GivenName");
         expect(value3.value).toBe("Tester");
-        expect(dvo.tags[0]).toBe("fake");
+        expect(dvo.tags![0]).toBe("fake");
         expect(dvo.createdAt).toStrictEqual(attribute.createdAt);
         expect(dvo.isOwn).toBe(true);
         expect(dvo.isValid).toBe(true);
@@ -195,7 +195,7 @@ describe("IQLQueryExpanded", () => {
         const givenName = dvo.value as AbstractStringJSON;
         expect(givenName["@type"]).toBe("GivenName");
         expect(givenName.value).toBe("Hugo");
-        expect(dvo.tags[0]).toBe("default");
+        expect(dvo.tags![0]).toBe("default");
         expect(dvo.createdAt).toStrictEqual(attribute.createdAt);
         expect(dvo.isOwn).toBe(true);
         expect(dvo.isValid).toBe(true);
@@ -240,7 +240,7 @@ describe("IQLQueryExpanded", () => {
         const givenName = dvo.value as AbstractStringJSON;
         expect(givenName["@type"]).toBe("GivenName");
         expect(givenName.value).toBe("Tester");
-        expect(dvo.tags[0]).toBe("fake");
+        expect(dvo.tags![0]).toBe("fake");
         expect(dvo.createdAt).toStrictEqual(attribute.createdAt);
         expect(dvo.isOwn).toBe(true);
         expect(dvo.isValid).toBe(true);
@@ -282,7 +282,7 @@ describe("IQLQueryExpanded", () => {
         const givenName = dvo.value as AbstractStringJSON;
         expect(givenName["@type"]).toBe("GivenName");
         expect(givenName.value).toBe("Tester");
-        expect(dvo.tags[0]).toBe("fake");
+        expect(dvo.tags![0]).toBe("fake");
         expect(dvo.createdAt).toStrictEqual(attribute.createdAt);
         expect(dvo.isOwn).toBe(true);
         expect(dvo.isValid).toBe(true);
@@ -306,7 +306,7 @@ describe("IQLQueryExpanded", () => {
         const value = dvo.value as AbstractStringJSON;
         expect(value["@type"]).toBe("Surname");
         expect(value.value).toBe("Nachname");
-        expect(dvo.tags[0]).toBe("fake");
+        expect(dvo.tags![0]).toBe("fake");
         expect(dvo.createdAt).toStrictEqual(attribute.createdAt);
         expect(dvo.isOwn).toBe(true);
         expect(dvo.isValid).toBe(true);

--- a/packages/runtime/test/dataViews/OwnSharedAttributeDVO.test.ts
+++ b/packages/runtime/test/dataViews/OwnSharedAttributeDVO.test.ts
@@ -1,5 +1,5 @@
-import { AbstractIntegerJSON, AbstractStringJSON } from "@nmshd/content";
-import { RepositoryAttributeDVO } from "../../src";
+import { AbstractIntegerJSON, AbstractStringJSON, IdentityAttributeJSON } from "@nmshd/content";
+import { SharedToPeerAttributeDVO } from "../../src";
 import { ensureActiveRelationship, executeFullCreateAndShareRepositoryAttributeFlow, RuntimeServiceProvider, TestRuntimeServices } from "../lib";
 
 const serviceProvider = new RuntimeServiceProvider();
@@ -30,27 +30,23 @@ describe("SharedToPeerAttributeDVO", () => {
                 }
             }
         });
-        const repositoryAttribute = (await services1.consumption.attributes.getAttribute({ id: ownSharedIdentityAttribute.shareInfo!.sourceAttribute! })).value;
-        const dtos = [(await services1.consumption.attributes.getAttribute({ id: repositoryAttribute.id })).value];
-        const dvos = await services1.expander.expandLocalAttributeDTOs(dtos);
-        expect(dvos).toHaveLength(1);
-        const dvo = dvos[0] as RepositoryAttributeDVO;
-        const attribute = repositoryAttribute;
+
+        const dto = (await services1.consumption.attributes.getAttribute({ id: ownSharedIdentityAttribute.id })).value;
+        const dvo = (await services1.expander.expandLocalAttributeDTO(dto)) as SharedToPeerAttributeDVO;
         expect(dvo).toBeDefined();
-        expect(dvo.type).toBe("RepositoryAttributeDVO");
-        expect(dvo.id).toStrictEqual(attribute.id);
+        expect(dvo.type).toBe("SharedToPeerAttributeDVO");
+        expect(dvo.id).toStrictEqual(ownSharedIdentityAttribute.id);
         expect(dvo.name).toBe("i18n://dvo.attribute.name.BirthYear");
         expect(dvo.description).toBe("i18n://dvo.attribute.description.BirthYear");
-        expect(dvo.date).toStrictEqual(attribute.createdAt);
-        expect(dvo.content).toStrictEqual(attribute.content);
+        expect(dvo.date).toStrictEqual(ownSharedIdentityAttribute.createdAt);
+        expect(dvo.content).toStrictEqual(ownSharedIdentityAttribute.content);
         const value = dvo.value as AbstractIntegerJSON;
         expect(value["@type"]).toBe("BirthYear");
         expect(value.value).toBe(2001);
-
-        expect(dvo.createdAt).toStrictEqual(attribute.createdAt);
+        expect(dvo.createdAt).toStrictEqual(ownSharedIdentityAttribute.createdAt);
         expect(dvo.isOwn).toBe(true);
         expect(dvo.isValid).toBe(true);
-        expect(dvo.owner).toStrictEqual(attribute.content.owner);
+        expect(dvo.owner).toStrictEqual(ownSharedIdentityAttribute.content.owner);
         expect(dvo.renderHints["@type"]).toBe("RenderHints");
         expect(dvo.renderHints.technicalType).toBe("Integer");
         expect(dvo.renderHints.editType).toBe("SelectLike");
@@ -58,17 +54,15 @@ describe("SharedToPeerAttributeDVO", () => {
         expect(dvo.valueHints["@type"]).toBe("ValueHints");
         expect(dvo.valueHints.min).toBe(1);
         expect(dvo.valueHints.max).toBe(9999);
-
-        expect(dvo.sharedWith).toHaveLength(1);
-        const shared = dvo.sharedWith[0];
-        const sharedAttribute = ownSharedIdentityAttribute;
-        expect(shared.id).toBe(sharedAttribute.id);
-        expect(shared.date).toBe(sharedAttribute.createdAt);
-        expect(shared.createdAt).toBe(sharedAttribute.createdAt);
-        expect(shared.peer).toBe(sharedAttribute.shareInfo!.peer);
-        expect(shared.requestReference).toBe(sharedAttribute.shareInfo!.requestReference);
-        expect(shared.notificationReference).toBe(sharedAttribute.shareInfo!.notificationReference);
-        expect(shared.sourceAttribute).toBe(sharedAttribute.shareInfo!.sourceAttribute);
+        expect(dvo.peer).toBe(ownSharedIdentityAttribute.shareInfo!.peer);
+        expect(dvo.isDraft).toBe(false);
+        expect(dvo.requestReference).toBe(ownSharedIdentityAttribute.shareInfo!.requestReference);
+        expect(dvo.notificationReference).toBe(ownSharedIdentityAttribute.shareInfo!.notificationReference);
+        expect(dvo.sourceAttribute).toBe(ownSharedIdentityAttribute.shareInfo!.sourceAttribute);
+        expect(dvo.tags).toBe((ownSharedIdentityAttribute.content as IdentityAttributeJSON).tags);
+        expect(dvo.valueType).toBe(ownSharedIdentityAttribute.content.value["@type"]);
+        expect(dvo.deletionStatus).toBe(ownSharedIdentityAttribute.deletionInfo?.deletionStatus);
+        expect(dvo.deletionDate).toBe(ownSharedIdentityAttribute.deletionInfo?.deletionDate);
     });
 
     test("check the Sex", async () => {
@@ -80,47 +74,41 @@ describe("SharedToPeerAttributeDVO", () => {
                 }
             }
         });
-        const repositoryAttribute = (await services1.consumption.attributes.getAttribute({ id: ownSharedIdentityAttribute.shareInfo!.sourceAttribute! })).value;
-        const dtos = [(await services1.consumption.attributes.getAttribute({ id: repositoryAttribute.id })).value];
-        const dvos = await services1.expander.expandLocalAttributeDTOs(dtos);
-        expect(dvos).toHaveLength(1);
-        const dvo = dvos[0] as RepositoryAttributeDVO;
-        const attribute = repositoryAttribute;
+
+        const dto = (await services1.consumption.attributes.getAttribute({ id: ownSharedIdentityAttribute.id })).value;
+        const dvo = (await services1.expander.expandLocalAttributeDTO(dto)) as SharedToPeerAttributeDVO;
         expect(dvo).toBeDefined();
-        expect(dvo.type).toBe("RepositoryAttributeDVO");
-        expect(dvo.id).toStrictEqual(attribute.id);
+        expect(dvo.type).toBe("SharedToPeerAttributeDVO");
+        expect(dvo.id).toStrictEqual(ownSharedIdentityAttribute.id);
         expect(dvo.name).toBe("i18n://dvo.attribute.name.Sex");
         expect(dvo.description).toBe("i18n://dvo.attribute.description.Sex");
-        expect(dvo.date).toStrictEqual(attribute.createdAt);
-        expect(dvo.content).toStrictEqual(attribute.content);
+        expect(dvo.date).toStrictEqual(ownSharedIdentityAttribute.createdAt);
+        expect(dvo.content).toStrictEqual(ownSharedIdentityAttribute.content);
         const value = dvo.value as AbstractStringJSON;
         expect(value["@type"]).toBe("Sex");
         expect(value.value).toBe("male");
-        expect(dvo.createdAt).toStrictEqual(attribute.createdAt);
+        expect(dvo.createdAt).toStrictEqual(ownSharedIdentityAttribute.createdAt);
         expect(dvo.isOwn).toBe(true);
         expect(dvo.isValid).toBe(true);
-        expect(dvo.owner).toStrictEqual(attribute.content.owner);
+        expect(dvo.owner).toStrictEqual(ownSharedIdentityAttribute.content.owner);
         expect(dvo.renderHints["@type"]).toBe("RenderHints");
         expect(dvo.renderHints.technicalType).toBe("String");
         expect(dvo.renderHints.editType).toBe("ButtonLike");
         expect(dvo.valueHints["@type"]).toBe("ValueHints");
-
         expect(dvo.valueHints.values).toStrictEqual([
             { key: "intersex", displayName: "i18n://attributes.values.sex.intersex" },
             { key: "female", displayName: "i18n://attributes.values.sex.female" },
             { key: "male", displayName: "i18n://attributes.values.sex.male" }
         ]);
-
-        expect(dvo.sharedWith).toHaveLength(1);
-        const shared = dvo.sharedWith[0];
-        const sharedAttribute = ownSharedIdentityAttribute;
-        expect(shared.id).toBe(sharedAttribute.id);
-        expect(shared.date).toBe(sharedAttribute.createdAt);
-        expect(shared.createdAt).toBe(sharedAttribute.createdAt);
-        expect(shared.peer).toBe(sharedAttribute.shareInfo!.peer);
-        expect(shared.requestReference).toBe(sharedAttribute.shareInfo!.requestReference);
-        expect(shared.notificationReference).toBe(sharedAttribute.shareInfo!.notificationReference);
-        expect(shared.sourceAttribute).toBe(sharedAttribute.shareInfo!.sourceAttribute);
+        expect(dvo.peer).toBe(ownSharedIdentityAttribute.shareInfo!.peer);
+        expect(dvo.isDraft).toBe(false);
+        expect(dvo.requestReference).toBe(ownSharedIdentityAttribute.shareInfo!.requestReference);
+        expect(dvo.notificationReference).toBe(ownSharedIdentityAttribute.shareInfo!.notificationReference);
+        expect(dvo.sourceAttribute).toBe(ownSharedIdentityAttribute.shareInfo!.sourceAttribute);
+        expect(dvo.tags).toBe((ownSharedIdentityAttribute.content as IdentityAttributeJSON).tags);
+        expect(dvo.valueType).toBe(ownSharedIdentityAttribute.content.value["@type"]);
+        expect(dvo.deletionStatus).toBe(ownSharedIdentityAttribute.deletionInfo?.deletionStatus);
+        expect(dvo.deletionDate).toBe(ownSharedIdentityAttribute.deletionInfo?.deletionDate);
     });
 
     test("check the Nationality", async () => {
@@ -132,26 +120,22 @@ describe("SharedToPeerAttributeDVO", () => {
                 }
             }
         });
-        const repositoryAttribute = (await services1.consumption.attributes.getAttribute({ id: ownSharedIdentityAttribute.shareInfo!.sourceAttribute! })).value;
-        const dtos = [(await services1.consumption.attributes.getAttribute({ id: repositoryAttribute.id })).value];
-        const dvos = await services1.expander.expandLocalAttributeDTOs(dtos);
-        expect(dvos).toHaveLength(1);
-        const dvo = dvos[0] as RepositoryAttributeDVO;
-        const attribute = repositoryAttribute;
+        const dto = (await services1.consumption.attributes.getAttribute({ id: ownSharedIdentityAttribute.id })).value;
+        const dvo = (await services1.expander.expandLocalAttributeDTO(dto)) as SharedToPeerAttributeDVO;
         expect(dvo).toBeDefined();
-        expect(dvo.type).toBe("RepositoryAttributeDVO");
-        expect(dvo.id).toStrictEqual(attribute.id);
+        expect(dvo.type).toBe("SharedToPeerAttributeDVO");
+        expect(dvo.id).toStrictEqual(ownSharedIdentityAttribute.id);
         expect(dvo.name).toBe("i18n://dvo.attribute.name.Nationality");
         expect(dvo.description).toBe("i18n://dvo.attribute.description.Nationality");
-        expect(dvo.date).toStrictEqual(attribute.createdAt);
-        expect(dvo.content).toStrictEqual(attribute.content);
+        expect(dvo.date).toStrictEqual(ownSharedIdentityAttribute.createdAt);
+        expect(dvo.content).toStrictEqual(ownSharedIdentityAttribute.content);
         const value = dvo.value as AbstractStringJSON;
         expect(value["@type"]).toBe("Nationality");
         expect(value.value).toBe("DE");
-        expect(dvo.createdAt).toStrictEqual(attribute.createdAt);
+        expect(dvo.createdAt).toStrictEqual(ownSharedIdentityAttribute.createdAt);
         expect(dvo.isOwn).toBe(true);
         expect(dvo.isValid).toBe(true);
-        expect(dvo.owner).toStrictEqual(attribute.content.owner);
+        expect(dvo.owner).toStrictEqual(ownSharedIdentityAttribute.content.owner);
         expect(dvo.renderHints["@type"]).toBe("RenderHints");
         expect(dvo.renderHints.technicalType).toBe("String");
         expect(dvo.renderHints.editType).toBe("SelectLike");
@@ -161,17 +145,15 @@ describe("SharedToPeerAttributeDVO", () => {
         expect(dvo.valueHints.max).toBe(2);
         expect(dvo.valueHints.values).toHaveLength(249);
         expect(dvo.valueHints.values![61]).toStrictEqual({ key: "DE", displayName: "i18n://attributes.values.countries.DE" });
-
-        expect(dvo.sharedWith).toHaveLength(1);
-        const shared = dvo.sharedWith[0];
-        const sharedAttribute = ownSharedIdentityAttribute;
-        expect(shared.id).toBe(sharedAttribute.id);
-        expect(shared.date).toBe(sharedAttribute.createdAt);
-        expect(shared.createdAt).toBe(sharedAttribute.createdAt);
-        expect(shared.peer).toBe(sharedAttribute.shareInfo!.peer);
-        expect(shared.requestReference).toBe(sharedAttribute.shareInfo!.requestReference);
-        expect(shared.notificationReference).toBe(sharedAttribute.shareInfo!.notificationReference);
-        expect(shared.sourceAttribute).toBe(sharedAttribute.shareInfo!.sourceAttribute);
+        expect(dvo.peer).toBe(ownSharedIdentityAttribute.shareInfo!.peer);
+        expect(dvo.isDraft).toBe(false);
+        expect(dvo.requestReference).toBe(ownSharedIdentityAttribute.shareInfo!.requestReference);
+        expect(dvo.notificationReference).toBe(ownSharedIdentityAttribute.shareInfo!.notificationReference);
+        expect(dvo.sourceAttribute).toBe(ownSharedIdentityAttribute.shareInfo!.sourceAttribute);
+        expect(dvo.tags).toBe((ownSharedIdentityAttribute.content as IdentityAttributeJSON).tags);
+        expect(dvo.valueType).toBe(ownSharedIdentityAttribute.content.value["@type"]);
+        expect(dvo.deletionStatus).toBe(ownSharedIdentityAttribute.deletionInfo?.deletionStatus);
+        expect(dvo.deletionDate).toBe(ownSharedIdentityAttribute.deletionInfo?.deletionDate);
     });
 
     test("check the CommunicationLanguage", async () => {
@@ -183,26 +165,23 @@ describe("SharedToPeerAttributeDVO", () => {
                 }
             }
         });
-        const repositoryAttribute = (await services1.consumption.attributes.getAttribute({ id: ownSharedIdentityAttribute.shareInfo!.sourceAttribute! })).value;
-        const dtos = [(await services1.consumption.attributes.getAttribute({ id: repositoryAttribute.id })).value];
-        const dvos = await services1.expander.expandLocalAttributeDTOs(dtos);
-        expect(dvos).toHaveLength(1);
-        const dvo = dvos[0] as RepositoryAttributeDVO;
-        const attribute = repositoryAttribute;
+
+        const dto = (await services1.consumption.attributes.getAttribute({ id: ownSharedIdentityAttribute.id })).value;
+        const dvo = (await services1.expander.expandLocalAttributeDTO(dto)) as SharedToPeerAttributeDVO;
         expect(dvo).toBeDefined();
-        expect(dvo.type).toBe("RepositoryAttributeDVO");
-        expect(dvo.id).toStrictEqual(attribute.id);
+        expect(dvo.type).toBe("SharedToPeerAttributeDVO");
+        expect(dvo.id).toStrictEqual(ownSharedIdentityAttribute.id);
         expect(dvo.name).toBe("i18n://dvo.attribute.name.CommunicationLanguage");
         expect(dvo.description).toBe("i18n://dvo.attribute.description.CommunicationLanguage");
-        expect(dvo.date).toStrictEqual(attribute.createdAt);
-        expect(dvo.content).toStrictEqual(attribute.content);
+        expect(dvo.date).toStrictEqual(ownSharedIdentityAttribute.createdAt);
+        expect(dvo.content).toStrictEqual(ownSharedIdentityAttribute.content);
         const value = dvo.value as AbstractStringJSON;
         expect(value["@type"]).toBe("CommunicationLanguage");
         expect(value.value).toBe("de");
-        expect(dvo.createdAt).toStrictEqual(attribute.createdAt);
+        expect(dvo.createdAt).toStrictEqual(ownSharedIdentityAttribute.createdAt);
         expect(dvo.isOwn).toBe(true);
         expect(dvo.isValid).toBe(true);
-        expect(dvo.owner).toStrictEqual(attribute.content.owner);
+        expect(dvo.owner).toStrictEqual(ownSharedIdentityAttribute.content.owner);
         expect(dvo.renderHints["@type"]).toBe("RenderHints");
         expect(dvo.renderHints.technicalType).toBe("String");
         expect(dvo.renderHints.editType).toBe("SelectLike");
@@ -212,16 +191,63 @@ describe("SharedToPeerAttributeDVO", () => {
         expect(dvo.valueHints.max).toBe(2);
         expect(dvo.valueHints.values).toHaveLength(183);
         expect(dvo.valueHints.values![31]).toStrictEqual({ key: "de", displayName: "i18n://attributes.values.languages.de" });
+        expect(dvo.peer).toBe(ownSharedIdentityAttribute.shareInfo!.peer);
+        expect(dvo.isDraft).toBe(false);
+        expect(dvo.requestReference).toBe(ownSharedIdentityAttribute.shareInfo!.requestReference);
+        expect(dvo.notificationReference).toBe(ownSharedIdentityAttribute.shareInfo!.notificationReference);
+        expect(dvo.sourceAttribute).toBe(ownSharedIdentityAttribute.shareInfo!.sourceAttribute);
+        expect(dvo.tags).toBe((ownSharedIdentityAttribute.content as IdentityAttributeJSON).tags);
+        expect(dvo.valueType).toBe(ownSharedIdentityAttribute.content.value["@type"]);
+        expect(dvo.deletionStatus).toBe(ownSharedIdentityAttribute.deletionInfo?.deletionStatus);
+        expect(dvo.deletionDate).toBe(ownSharedIdentityAttribute.deletionInfo?.deletionDate);
+    });
 
-        expect(dvo.sharedWith).toHaveLength(1);
-        const shared = dvo.sharedWith[0];
-        const sharedAttribute = ownSharedIdentityAttribute;
-        expect(shared.id).toBe(sharedAttribute.id);
-        expect(shared.date).toBe(sharedAttribute.createdAt);
-        expect(shared.createdAt).toBe(sharedAttribute.createdAt);
-        expect(shared.peer).toBe(sharedAttribute.shareInfo!.peer);
-        expect(shared.requestReference).toBe(sharedAttribute.shareInfo!.requestReference);
-        expect(shared.notificationReference).toBe(sharedAttribute.shareInfo!.notificationReference);
-        expect(shared.sourceAttribute).toBe(sharedAttribute.shareInfo!.sourceAttribute);
+    test("check the CommunicationLanguage after the RepositoryAttribute was deleted", async () => {
+        const ownSharedIdentityAttribute = await executeFullCreateAndShareRepositoryAttributeFlow(services1, services2, {
+            content: {
+                value: {
+                    "@type": "CommunicationLanguage",
+                    value: "de"
+                }
+            }
+        });
+        const repositoryAttribute = (await services1.consumption.attributes.getAttribute({ id: ownSharedIdentityAttribute.shareInfo!.sourceAttribute! })).value;
+        await services1.consumption.attributes.deleteRepositoryAttribute({ attributeId: repositoryAttribute.id });
+        const updatedOwnSharedIdentityAttribute = (await services1.consumption.attributes.getAttribute({ id: ownSharedIdentityAttribute.id })).value;
+
+        const dto = (await services1.consumption.attributes.getAttribute({ id: updatedOwnSharedIdentityAttribute.id })).value;
+        const dvo = (await services1.expander.expandLocalAttributeDTO(dto)) as SharedToPeerAttributeDVO;
+        expect(dvo).toBeDefined();
+        expect(dvo.type).toBe("SharedToPeerAttributeDVO");
+        expect(dvo.id).toStrictEqual(updatedOwnSharedIdentityAttribute.id);
+        expect(dvo.name).toBe("i18n://dvo.attribute.name.CommunicationLanguage");
+        expect(dvo.description).toBe("i18n://dvo.attribute.description.CommunicationLanguage");
+        expect(dvo.date).toStrictEqual(updatedOwnSharedIdentityAttribute.createdAt);
+        expect(dvo.content).toStrictEqual(updatedOwnSharedIdentityAttribute.content);
+        const value = dvo.value as AbstractStringJSON;
+        expect(value["@type"]).toBe("CommunicationLanguage");
+        expect(value.value).toBe("de");
+        expect(dvo.createdAt).toStrictEqual(updatedOwnSharedIdentityAttribute.createdAt);
+        expect(dvo.isOwn).toBe(true);
+        expect(dvo.isValid).toBe(true);
+        expect(dvo.owner).toStrictEqual(updatedOwnSharedIdentityAttribute.content.owner);
+        expect(dvo.renderHints["@type"]).toBe("RenderHints");
+        expect(dvo.renderHints.technicalType).toBe("String");
+        expect(dvo.renderHints.editType).toBe("SelectLike");
+        expect(dvo.renderHints.dataType).toBe("Language");
+        expect(dvo.valueHints["@type"]).toBe("ValueHints");
+        expect(dvo.valueHints.min).toBe(2);
+        expect(dvo.valueHints.max).toBe(2);
+        expect(dvo.valueHints.values).toHaveLength(183);
+        expect(dvo.valueHints.values![31]).toStrictEqual({ key: "de", displayName: "i18n://attributes.values.languages.de" });
+        expect(dvo.peer).toBe(updatedOwnSharedIdentityAttribute.shareInfo!.peer);
+        expect(dvo.isDraft).toBe(false);
+        expect(dvo.requestReference).toBe(updatedOwnSharedIdentityAttribute.shareInfo!.requestReference);
+        expect(dvo.notificationReference).toBe(updatedOwnSharedIdentityAttribute.shareInfo!.notificationReference);
+        expect(dvo.sourceAttribute).toBe(updatedOwnSharedIdentityAttribute.shareInfo!.sourceAttribute);
+        expect(dvo.tags).toBe((updatedOwnSharedIdentityAttribute.content as IdentityAttributeJSON).tags);
+        expect(dvo.valueType).toBe(updatedOwnSharedIdentityAttribute.content.value["@type"]);
+        expect(dvo.deletionStatus).toBe(updatedOwnSharedIdentityAttribute.deletionInfo?.deletionStatus);
+        expect(dvo.deletionDate).toBe(updatedOwnSharedIdentityAttribute.deletionInfo?.deletionDate);
     });
 });


### PR DESCRIPTION
Firstly, I noticed that the OwnSharedAttributeDVO test doesn't test SharedToPeerAttributeDVOs, but only RepositoryAttributeDVOs. Adjusting it, I noticed that we have a mismatch in the tags property concerning IdentityAttribute DTOs and DVOs.