### PR TITLE
Fix/local development with different ways to connect to the backbone

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12546,7 +12546,7 @@
         },
         "packages/app-runtime": {
             "name": "@nmshd/app-runtime",
-            "version": "5.0.0-alpha.8",
+            "version": "5.0.0-alpha.9",
             "license": "MIT",
             "dependencies": {
                 "@js-soft/docdb-access-loki": "^1.1.0",
@@ -12560,12 +12560,12 @@
                 "@types/luxon": "^3.4.2"
             },
             "peerDependencies": {
-                "@nmshd/runtime": "^5.0.0-alpha.8"
+                "@nmshd/runtime": "^5.0.0-alpha.9"
             }
         },
         "packages/consumption": {
             "name": "@nmshd/consumption",
-            "version": "5.0.0-alpha.8",
+            "version": "5.0.0-alpha.9",
             "license": "MIT",
             "dependencies": {
                 "@js-soft/docdb-querytranslator": "^1.1.4",
@@ -12587,7 +12587,7 @@
         },
         "packages/content": {
             "name": "@nmshd/content",
-            "version": "5.0.0-alpha.8",
+            "version": "5.0.0-alpha.9",
             "license": "MIT",
             "dependencies": {
                 "@js-soft/logging-abstractions": "^1.0.1",
@@ -12612,17 +12612,17 @@
         },
         "packages/runtime": {
             "name": "@nmshd/runtime",
-            "version": "5.0.0-alpha.8",
+            "version": "5.0.0-alpha.9",
             "license": "MIT",
             "dependencies": {
                 "@js-soft/docdb-querytranslator": "^1.1.4",
                 "@js-soft/logging-abstractions": "^1.0.1",
                 "@js-soft/ts-serval": "2.0.10",
                 "@js-soft/ts-utils": "^2.3.3",
-                "@nmshd/consumption": "5.0.0-alpha.8",
-                "@nmshd/content": "5.0.0-alpha.8",
+                "@nmshd/consumption": "5.0.0-alpha.9",
+                "@nmshd/content": "5.0.0-alpha.9",
                 "@nmshd/crypto": "2.0.6",
-                "@nmshd/transport": "5.0.0-alpha.8",
+                "@nmshd/transport": "5.0.0-alpha.9",
                 "ajv": "^8.17.1",
                 "ajv-errors": "^3.0.0",
                 "ajv-formats": "^3.0.1",
@@ -12654,7 +12654,7 @@
         },
         "packages/transport": {
             "name": "@nmshd/transport",
-            "version": "5.0.0-alpha.8",
+            "version": "5.0.0-alpha.9",
             "license": "MIT",
             "dependencies": {
                 "@js-soft/docdb-access-abstractions": "1.0.4",

--- a/packages/app-runtime/package.json
+++ b/packages/app-runtime/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nmshd/app-runtime",
-    "version": "5.0.0-alpha.8",
+    "version": "5.0.0-alpha.9",
     "description": "The App Runtime",
     "homepage": "https://enmeshed.eu",
     "repository": {
@@ -54,7 +54,7 @@
         "@types/luxon": "^3.4.2"
     },
     "peerDependencies": {
-        "@nmshd/runtime": "^5.0.0-alpha.8"
+        "@nmshd/runtime": "^5.0.0-alpha.9"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/consumption/package.json
+++ b/packages/consumption/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nmshd/consumption",
-    "version": "5.0.0-alpha.8",
+    "version": "5.0.0-alpha.9",
     "description": "The consumption library extends the transport library.",
     "homepage": "https://enmeshed.eu",
     "repository": {

--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nmshd/content",
-    "version": "5.0.0-alpha.8",
+    "version": "5.0.0-alpha.9",
     "description": "The content library defines data structures that can be transmitted using the transport library.",
     "homepage": "https://enmeshed.eu",
     "repository": {

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nmshd/runtime",
-    "version": "5.0.0-alpha.8",
+    "version": "5.0.0-alpha.9",
     "description": "The enmeshed client runtime.",
     "homepage": "https://enmeshed.eu",
     "repository": {
@@ -56,10 +56,10 @@
         "@js-soft/logging-abstractions": "^1.0.1",
         "@js-soft/ts-serval": "2.0.10",
         "@js-soft/ts-utils": "^2.3.3",
-        "@nmshd/consumption": "5.0.0-alpha.8",
-        "@nmshd/content": "5.0.0-alpha.8",
+        "@nmshd/consumption": "5.0.0-alpha.9",
+        "@nmshd/content": "5.0.0-alpha.9",
         "@nmshd/crypto": "2.0.6",
-        "@nmshd/transport": "5.0.0-alpha.8",
+        "@nmshd/transport": "5.0.0-alpha.9",
         "ajv": "^8.17.1",
         "ajv-errors": "^3.0.0",
         "ajv-formats": "^3.0.1",

--- a/packages/transport/package.json
+++ b/packages/transport/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nmshd/transport",
-    "version": "5.0.0-alpha.8",
+    "version": "5.0.0-alpha.9",
     "description": "The transport library handles backbone communication and content encryption.",
     "homepage": "https://enmeshed.eu",
     "repository": {

--- a/packages/transport/src/core/Transport.ts
+++ b/packages/transport/src/core/Transport.ts
@@ -24,6 +24,7 @@ export interface IConfig {
     platformMaxUnencryptedFileSize: number;
     platformAdditionalHeaders?: Record<string, string>;
     baseUrl: string;
+    addressGenerationBaseUrlOverride?: string;
     datawalletEnabled: boolean;
     httpAgentOptions: AgentOptions;
     httpsAgentOptions: HTTPSAgentOptions;
@@ -40,6 +41,7 @@ export interface IConfigOverwrite {
     platformMaxUnencryptedFileSize?: number;
     platformAdditionalHeaders?: Record<string, string>;
     baseUrl: string;
+    addressGenerationBaseUrlOverride?: string;
     datawalletEnabled?: boolean;
     httpAgentOptions?: AgentOptions;
     httpsAgentOptions?: HTTPSAgentOptions;

--- a/packages/transport/src/core/Transport.ts
+++ b/packages/transport/src/core/Transport.ts
@@ -24,7 +24,7 @@ export interface IConfig {
     platformMaxUnencryptedFileSize: number;
     platformAdditionalHeaders?: Record<string, string>;
     baseUrl: string;
-    addressGenerationBaseUrlOverride?: string;
+    addressGenerationHostnameOverride?: string;
     datawalletEnabled: boolean;
     httpAgentOptions: AgentOptions;
     httpsAgentOptions: HTTPSAgentOptions;
@@ -41,7 +41,7 @@ export interface IConfigOverwrite {
     platformMaxUnencryptedFileSize?: number;
     platformAdditionalHeaders?: Record<string, string>;
     baseUrl: string;
-    addressGenerationBaseUrlOverride?: string;
+    addressGenerationHostnameOverride?: string;
     datawalletEnabled?: boolean;
     httpAgentOptions?: AgentOptions;
     httpsAgentOptions?: HTTPSAgentOptions;

--- a/packages/transport/src/modules/accounts/AccountController.ts
+++ b/packages/transport/src/modules/accounts/AccountController.ts
@@ -279,7 +279,7 @@ export class AccountController {
             CoreCrypto.generateSecretKey(),
 
             // Generate address locally
-            IdentityUtil.createAddress(identityKeypair.publicKey, this._config.addressGenerationBaseUrlOverride ?? new URL(this._config.baseUrl).hostname),
+            IdentityUtil.createAddress(identityKeypair.publicKey, this._config.addressGenerationHostnameOverride ?? new URL(this._config.baseUrl).hostname),
             this.fetchDeviceInfo()
         ]);
 

--- a/packages/transport/src/modules/accounts/AccountController.ts
+++ b/packages/transport/src/modules/accounts/AccountController.ts
@@ -279,7 +279,7 @@ export class AccountController {
             CoreCrypto.generateSecretKey(),
 
             // Generate address locally
-            IdentityUtil.createAddress(identityKeypair.publicKey, new URL(this._config.baseUrl).hostname),
+            IdentityUtil.createAddress(identityKeypair.publicKey, this._config.addressGenerationBaseUrlOverride ?? new URL(this._config.baseUrl).hostname),
             this.fetchDeviceInfo()
         ]);
 

--- a/packages/transport/src/modules/accounts/AccountController.ts
+++ b/packages/transport/src/modules/accounts/AccountController.ts
@@ -295,34 +295,7 @@ export class AccountController {
         this._log.trace(`Registered identity with address ${deviceResponse.address}, device id is ${deviceResponse.device.id}.`);
 
         if (!localAddress.equals(deviceResponse.address)) {
-            const baseErrorMessage = "The backbone address does not match the local address.";
-
-            if (localAddress.address.startsWith("did:e:") && deviceResponse.address.startsWith("did:e:")) {
-                throw new TransportError(`${baseErrorMessage} One of the addresses does not start with 'did:e:'.`);
-            }
-
-            const localSegments = localAddress.address.split(":");
-            const backboneSegments = deviceResponse.address.split(":");
-
-            if (localSegments.length !== 5 || backboneSegments.length !== 5) {
-                throw new TransportError(`${baseErrorMessage} One of the addresses does not have 5 segments.`);
-            }
-
-            const localAddressPart = localSegments[2];
-            const backboneAddressPart = backboneSegments[2];
-
-            if (localAddressPart !== backboneAddressPart) {
-                throw new TransportError(`${baseErrorMessage} The address parts do not match. Local: ${localAddressPart}, Backbone: ${backboneAddressPart}.`);
-            }
-
-            const localPubkeyPart = localSegments[4];
-            const backbonePubkeyPart = backboneSegments[4];
-
-            if (localPubkeyPart !== backbonePubkeyPart) {
-                throw new TransportError(`${baseErrorMessage} The generated public key parts do not match.`);
-            }
-
-            throw new TransportError(`${baseErrorMessage} The addresses do not match.`);
+            throw new TransportError(`The backbone address '${deviceResponse.address}' does not match the local address '${localAddress.toString()}'.`);
         }
 
         const identity = Identity.from({

--- a/packages/transport/src/modules/accounts/AccountController.ts
+++ b/packages/transport/src/modules/accounts/AccountController.ts
@@ -295,7 +295,34 @@ export class AccountController {
         this._log.trace(`Registered identity with address ${deviceResponse.address}, device id is ${deviceResponse.device.id}.`);
 
         if (!localAddress.equals(deviceResponse.address)) {
-            throw new TransportError("The backbone address does not match the local address.");
+            const baseErrorMessage = "The backbone address does not match the local address.";
+
+            if (localAddress.address.startsWith("did:e:") && deviceResponse.address.startsWith("did:e:")) {
+                throw new TransportError(`${baseErrorMessage} One of the addresses does not start with 'did:e:'.`);
+            }
+
+            const localSegments = localAddress.address.split(":");
+            const backboneSegments = deviceResponse.address.split(":");
+
+            if (localSegments.length !== 5 || backboneSegments.length !== 5) {
+                throw new TransportError(`${baseErrorMessage} One of the addresses does not have 5 segments.`);
+            }
+
+            const localAddressPart = localSegments[2];
+            const backboneAddressPart = backboneSegments[2];
+
+            if (localAddressPart !== backboneAddressPart) {
+                throw new TransportError(`${baseErrorMessage} The address parts do not match. Local: ${localAddressPart}, Backbone: ${backboneAddressPart}.`);
+            }
+
+            const localPubkeyPart = localSegments[4];
+            const backbonePubkeyPart = backboneSegments[4];
+
+            if (localPubkeyPart !== backbonePubkeyPart) {
+                throw new TransportError(`${baseErrorMessage} The generated public key parts do not match.`);
+            }
+
+            throw new TransportError(`${baseErrorMessage} The addresses do not match.`);
         }
 
         const identity = Identity.from({


### PR DESCRIPTION
When developing against a local backbone the backbone is always configured with `Application.didDomainName` set to `localhost`. There are different ways to connect to this connector (e.g. through the hostname in the docker network e.g. `"consumer-api"` or `"host.docker.internal"`. All these versions result into an address mismatch of the local generated address and the backbones.

This PR resolves this by providing a so called `addressGenerationHostnameOverride` that overrides that behavior of the runtime extracting the hostname for the address generation from the baseUrl.

this means you can configure the transport lib as follows:
```
{
  "baseUrl": "http://host.docker.internal:8080",
  "addressGenerationHostnameOverride": "localhost",
  ...
}
```

I am not really sure if the naming of the new config flag is the best, I'm open for suggestions here!