### PR TITLE
Fix/display unknown identities as unknown instead of a random string

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12548,7 +12548,7 @@
         },
         "packages/app-runtime": {
             "name": "@nmshd/app-runtime",
-            "version": "5.0.0-alpha.14",
+            "version": "5.0.0-alpha.15",
             "license": "MIT",
             "dependencies": {
                 "@js-soft/docdb-access-loki": "^1.1.0",
@@ -12562,12 +12562,12 @@
                 "@types/luxon": "^3.4.2"
             },
             "peerDependencies": {
-                "@nmshd/runtime": "^5.0.0-alpha.14"
+                "@nmshd/runtime": "^5.0.0-alpha.15"
             }
         },
         "packages/consumption": {
             "name": "@nmshd/consumption",
-            "version": "5.0.0-alpha.14",
+            "version": "5.0.0-alpha.15",
             "license": "MIT",
             "dependencies": {
                 "@js-soft/docdb-querytranslator": "^1.1.4",
@@ -12589,7 +12589,7 @@
         },
         "packages/content": {
             "name": "@nmshd/content",
-            "version": "5.0.0-alpha.14",
+            "version": "5.0.0-alpha.15",
             "license": "MIT",
             "dependencies": {
                 "@js-soft/logging-abstractions": "^1.0.1",
@@ -12614,17 +12614,17 @@
         },
         "packages/runtime": {
             "name": "@nmshd/runtime",
-            "version": "5.0.0-alpha.14",
+            "version": "5.0.0-alpha.15",
             "license": "MIT",
             "dependencies": {
                 "@js-soft/docdb-querytranslator": "^1.1.4",
                 "@js-soft/logging-abstractions": "^1.0.1",
                 "@js-soft/ts-serval": "2.0.10",
                 "@js-soft/ts-utils": "^2.3.3",
-                "@nmshd/consumption": "5.0.0-alpha.14",
-                "@nmshd/content": "5.0.0-alpha.14",
+                "@nmshd/consumption": "5.0.0-alpha.15",
+                "@nmshd/content": "5.0.0-alpha.15",
                 "@nmshd/crypto": "2.0.6",
-                "@nmshd/transport": "5.0.0-alpha.14",
+                "@nmshd/transport": "5.0.0-alpha.15",
                 "ajv": "^8.17.1",
                 "ajv-errors": "^3.0.0",
                 "ajv-formats": "^3.0.1",
@@ -12656,7 +12656,7 @@
         },
         "packages/transport": {
             "name": "@nmshd/transport",
-            "version": "5.0.0-alpha.14",
+            "version": "5.0.0-alpha.15",
             "license": "MIT",
             "dependencies": {
                 "@js-soft/docdb-access-abstractions": "1.0.4",

--- a/packages/app-runtime/package.json
+++ b/packages/app-runtime/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nmshd/app-runtime",
-    "version": "5.0.0-alpha.14",
+    "version": "5.0.0-alpha.15",
     "description": "The App Runtime",
     "homepage": "https://enmeshed.eu",
     "repository": {
@@ -54,7 +54,7 @@
         "@types/luxon": "^3.4.2"
     },
     "peerDependencies": {
-        "@nmshd/runtime": "^5.0.0-alpha.14"
+        "@nmshd/runtime": "^5.0.0-alpha.15"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/app-runtime/test/modules/MessageEventing.test.ts
+++ b/packages/app-runtime/test/modules/MessageEventing.test.ts
@@ -54,6 +54,6 @@ describe("MessageEventingTest", function () {
         expect(mailReceivedEvent.data.date).toBe(message.createdAt);
         expect(mailReceivedEvent.data.type).toBe("MailDVO");
         expect(mailReceivedEvent.data.createdBy.type).toBe("IdentityDVO");
-        expect(mailReceivedEvent.data.createdBy.name).toBe(createdBy.substring(3, 9));
+        expect(mailReceivedEvent.data.createdBy.name).toBe("i18n://dvo.identity.unknown");
     });
 });

--- a/packages/app-runtime/test/modules/RelationshipEventingAccept.test.ts
+++ b/packages/app-runtime/test/modules/RelationshipEventingAccept.test.ts
@@ -45,7 +45,7 @@ describe("RelationshipEventingAcceptTest", function () {
         expect(onboardingChangeReceivedEvent.data.auditLogEntry.newStatus).toBe(RelationshipStatus.Pending);
         expect(onboardingChangeReceivedEvent.data.identity).toBeDefined();
         expect(onboardingChangeReceivedEvent.data.identity.id).toBe(sessionB.address.toString());
-        expect(onboardingChangeReceivedEvent.data.identity.name).toBe(sessionB.address.toString().substring(3, 9));
+        expect(onboardingChangeReceivedEvent.data.identity.name).toBe("i18n://dvo.identity.unknown");
         expect(onboardingChangeReceivedEvent.data.identity.hasRelationship).toBe(true);
         expect(onboardingChangeReceivedEvent.data.identity.relationship?.id).toBe(relationshipChangedEvent.data.id);
         expect(onboardingChangeReceivedEvent.data.relationship).toBe(relationshipChangedEvent.data);
@@ -86,7 +86,7 @@ describe("RelationshipEventingAcceptTest", function () {
         expect(onboardingChangeReceivedEvent.data).toBeDefined();
         expect(onboardingChangeReceivedEvent.data.auditLogEntry.newStatus).toBe(RelationshipStatus.Active);
         expect(onboardingChangeReceivedEvent.data.identity).toBeDefined();
-        expect(onboardingChangeReceivedEvent.data.identity.name).toBe(sessionA.accountController.identity.address.toString().substring(3, 9));
+        expect(onboardingChangeReceivedEvent.data.identity.name).toBe("i18n://dvo.identity.unknown");
         expect(onboardingChangeReceivedEvent.data.identity.id).toBe(sessionA.accountController.identity.address.toString());
         expect(onboardingChangeReceivedEvent.data.identity.hasRelationship).toBe(true);
         expect(onboardingChangeReceivedEvent.data.identity.relationship?.id).toBe(relationshipChangedEvent.data.id);

--- a/packages/app-runtime/test/modules/RelationshipEventingReject.test.ts
+++ b/packages/app-runtime/test/modules/RelationshipEventingReject.test.ts
@@ -44,7 +44,7 @@ describe("RelationshipEventingRejectTest", function () {
         expect(onboardingChangeReceivedEvent.data).toBeDefined();
         expect(onboardingChangeReceivedEvent.data.auditLogEntry.newStatus).toBe(RelationshipStatus.Pending);
         expect(onboardingChangeReceivedEvent.data.identity).toBeDefined();
-        expect(onboardingChangeReceivedEvent.data.identity.name).toBe(sessionB.accountController.identity.address.toString().substring(3, 9));
+        expect(onboardingChangeReceivedEvent.data.identity.name).toBe("i18n://dvo.identity.unknown");
         expect(onboardingChangeReceivedEvent.data.identity.id).toBe(sessionB.accountController.identity.address.toString());
 
         expect(onboardingChangeReceivedEvent.data.relationship).toBe(relationshipChangedEvent.data);
@@ -86,7 +86,7 @@ describe("RelationshipEventingRejectTest", function () {
         expect(onboardingChangeReceivedEvent.data.auditLogEntry.newStatus).toBe(RelationshipStatus.Rejected);
         expect(onboardingChangeReceivedEvent.data.identity).toBeDefined();
 
-        expect(onboardingChangeReceivedEvent.data.identity.name).toBe(sessionA.accountController.identity.address.toString().substring(3, 9));
+        expect(onboardingChangeReceivedEvent.data.identity.name).toBe("i18n://dvo.identity.unknown");
         expect(onboardingChangeReceivedEvent.data.identity.id).toBe(sessionA.accountController.identity.address.toString());
         expect(onboardingChangeReceivedEvent.data.identity.hasRelationship).toBe(true);
         expect(onboardingChangeReceivedEvent.data.identity.relationship?.id).toBe(relationshipChangedEvent.data.id);

--- a/packages/app-runtime/test/modules/RelationshipEventingRevoke.test.ts
+++ b/packages/app-runtime/test/modules/RelationshipEventingRevoke.test.ts
@@ -46,7 +46,7 @@ describe("RelationshipEventingRevokeTest", function () {
         expect(onboardingChangeReceivedEvent.data.auditLogEntry.newStatus).toBe(RelationshipStatus.Pending);
         expect(onboardingChangeReceivedEvent.data.identity).toBeDefined();
 
-        expect(onboardingChangeReceivedEvent.data.identity.name).toBe(sessionB.accountController.identity.address.toString().substring(3, 9));
+        expect(onboardingChangeReceivedEvent.data.identity.name).toBe("i18n://dvo.identity.unknown");
         expect(onboardingChangeReceivedEvent.data.identity.id).toBe(sessionB.accountController.identity.address.toString());
 
         expect(onboardingChangeReceivedEvent.data.identity.hasRelationship).toBe(true);
@@ -88,7 +88,7 @@ describe("RelationshipEventingRevokeTest", function () {
         expect(onboardingChangeReceivedEvent.data.auditLogEntry.newStatus).toBe(RelationshipStatus.Revoked);
         expect(onboardingChangeReceivedEvent.data.identity).toBeDefined();
 
-        expect(onboardingChangeReceivedEvent.data.identity.name).toBe(sessionB.accountController.identity.address.toString().substring(3, 9));
+        expect(onboardingChangeReceivedEvent.data.identity.name).toBe("i18n://dvo.identity.unknown");
         expect(onboardingChangeReceivedEvent.data.identity.id).toBe(sessionB.accountController.identity.address.toString());
         expect(onboardingChangeReceivedEvent.data.identity.hasRelationship).toBe(true);
         expect(onboardingChangeReceivedEvent.data.identity.relationship?.id).toBe(relationshipChangedEvent.data.id);

--- a/packages/consumption/package.json
+++ b/packages/consumption/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nmshd/consumption",
-    "version": "5.0.0-alpha.14",
+    "version": "5.0.0-alpha.15",
     "description": "The consumption library extends the transport library.",
     "homepage": "https://enmeshed.eu",
     "repository": {

--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nmshd/content",
-    "version": "5.0.0-alpha.14",
+    "version": "5.0.0-alpha.15",
     "description": "The content library defines data structures that can be transmitted using the transport library.",
     "homepage": "https://enmeshed.eu",
     "repository": {

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nmshd/runtime",
-    "version": "5.0.0-alpha.14",
+    "version": "5.0.0-alpha.15",
     "description": "The enmeshed client runtime.",
     "homepage": "https://enmeshed.eu",
     "repository": {
@@ -56,10 +56,10 @@
         "@js-soft/logging-abstractions": "^1.0.1",
         "@js-soft/ts-serval": "2.0.10",
         "@js-soft/ts-utils": "^2.3.3",
-        "@nmshd/consumption": "5.0.0-alpha.14",
-        "@nmshd/content": "5.0.0-alpha.14",
+        "@nmshd/consumption": "5.0.0-alpha.15",
+        "@nmshd/content": "5.0.0-alpha.15",
         "@nmshd/crypto": "2.0.6",
-        "@nmshd/transport": "5.0.0-alpha.14",
+        "@nmshd/transport": "5.0.0-alpha.15",
         "ajv": "^8.17.1",
         "ajv-errors": "^3.0.0",
         "ajv-formats": "^3.0.1",

--- a/packages/runtime/src/dataViews/DataViewExpander.ts
+++ b/packages/runtime/src/dataViews/DataViewExpander.ts
@@ -1577,14 +1577,11 @@ export class DataViewExpander {
     }
 
     public expandUnknown(address: string): IdentityDVO {
-        const name = address.substring(3, 9);
-        const initials = (name.match(/\b\w/g) ?? []).join("");
-
         return {
             id: address,
             type: "IdentityDVO",
-            name: name,
-            initials: initials,
+            name: "i18n://dvo.identity.unknown",
+            initials: "",
             description: "i18n://dvo.identity.unknown.description",
             isSelf: false,
             hasRelationship: false
@@ -1639,7 +1636,7 @@ export class DataViewExpander {
     private expandAddressFromRequest(request: LocalRequestDTO): IdentityDVO {
         const sharedAttributesOnNewRelationship = this.getSharedAttributesFromRequest(request);
         const address = request.peer;
-        const name = this.getNameFromAttributeContents(sharedAttributesOnNewRelationship) ?? address.substring(3, 9);
+        const name = this.getNameFromAttributeContents(sharedAttributesOnNewRelationship) ?? "i18n://dvo.identity.unknown";
         const initials = (name.match(/\b\w/g) ?? []).join("");
 
         return {
@@ -1775,7 +1772,7 @@ export class DataViewExpander {
         } else if (stringByType["Surname"]) {
             name = `${stringByType["Surname"]}`;
         } else {
-            name = relationship.peer.substring(3, 9);
+            name = "i18n://dvo.identity.unknown";
         }
 
         return {
@@ -1831,16 +1828,13 @@ export class DataViewExpander {
 
         if (relationshipResult.error.code !== RuntimeErrors.general.recordNotFound(Relationship).code) throw relationshipResult.error;
 
-        const name = address.substring(3, 9);
-        const initials = (name.match(/\b\w/g) ?? []).join("");
-
         return {
             id: address,
             type: "IdentityDVO",
-            name: name,
-            initials: initials,
+            name: "i18n://dvo.identity.unknown",
+            initials: "",
             publicKey: "i18n://dvo.identity.publicKey.unknown",
-            description: "i18n://dvo.identity.unknown",
+            description: "i18n://dvo.identity.unknown.description",
             isSelf: false,
             hasRelationship: false
         };

--- a/packages/runtime/test/dataViews/MessageDVO.test.ts
+++ b/packages/runtime/test/dataViews/MessageDVO.test.ts
@@ -107,7 +107,7 @@ describe("MessageDVO", () => {
         const recipient = dvo.recipients[0];
         expect(recipient.type).toBe("RecipientDVO");
         expect(recipient.id).toStrictEqual(dto.recipients[0].address);
-        expect(recipient.name).toBe("i18n://dvo.identity.unknown"); // "Barbara"
+        expect(recipient.name).toBe("i18n://dvo.identity.unknown");
         expect(recipient.isSelf).toBe(false);
         expect(dvo.status).toBe("Delivering");
     });

--- a/packages/runtime/test/dataViews/MessageDVO.test.ts
+++ b/packages/runtime/test/dataViews/MessageDVO.test.ts
@@ -107,7 +107,7 @@ describe("MessageDVO", () => {
         const recipient = dvo.recipients[0];
         expect(recipient.type).toBe("RecipientDVO");
         expect(recipient.id).toStrictEqual(dto.recipients[0].address);
-        expect(recipient.name).toBe(recipient.id.substring(3, 9)); // "Barbara"
+        expect(recipient.name).toBe("i18n://dvo.identity.unknown"); // "Barbara"
         expect(recipient.isSelf).toBe(false);
         expect(dvo.status).toBe("Delivering");
     });
@@ -129,7 +129,7 @@ describe("MessageDVO", () => {
         expect(dvo.isOwn).toBe(false);
         expect(dvo.createdBy.type).toBe("IdentityDVO");
         expect(dvo.createdBy.id).toStrictEqual(dto.createdBy);
-        expect(dvo.createdBy.name).toBe(dvo.createdBy.id.substring(3, 9)); // "Jürgen"
+        expect(dvo.createdBy.name).toBe("i18n://dvo.identity.unknown");
         expect(dvo.createdBy.isSelf).toBe(false);
         const recipient = dvo.recipients[0];
         expect(recipient.type).toBe("RecipientDVO");
@@ -164,14 +164,14 @@ describe("MessageDVO", () => {
         const recipient = dvo.recipients[0];
         expect(recipient.type).toBe("RecipientDVO");
         expect(recipient.id).toStrictEqual(dto.recipients[0].address);
-        expect(recipient.name).toBe(recipient.id.substring(3, 9)); // "Barbara"
+        expect(recipient.name).toBe("i18n://dvo.identity.unknown");
         expect(recipient.isSelf).toBe(false);
 
         expect(dvo.to).toHaveLength(1);
         const to = dvo.to[0];
         expect(to.type).toBe("RecipientDVO");
         expect(to.id).toStrictEqual(mail.to[0]);
-        expect(to.name).toBe(to.id.substring(3, 9)); // "Barbara"
+        expect(to.name).toBe("i18n://dvo.identity.unknown");
         expect(to.isSelf).toBe(false);
         expect(dvo.toCount).toStrictEqual(mail.to.length);
         expect(dvo.ccCount).toStrictEqual(mail.cc!.length);
@@ -198,7 +198,7 @@ describe("MessageDVO", () => {
         expect(dvo.isOwn).toBe(false);
         expect(dvo.createdBy.type).toBe("IdentityDVO");
         expect(dvo.createdBy.id).toStrictEqual(dto.createdBy);
-        expect(dvo.createdBy.name).toBe(dvo.createdBy.id.substring(3, 9)); // "Jürgen"
+        expect(dvo.createdBy.name).toBe("i18n://dvo.identity.unknown");
         expect(dvo.createdBy.isSelf).toBe(false);
         const recipient = dvo.recipients[0];
         expect(recipient.type).toBe("RecipientDVO");

--- a/packages/runtime/test/dataViews/RelationshipDVO.test.ts
+++ b/packages/runtime/test/dataViews/RelationshipDVO.test.ts
@@ -62,7 +62,7 @@ describe("RelationshipDVO", () => {
         const dvo = dvos[0];
         expect(dvo).toBeDefined();
         expect(dvo.id).toBe(dto.peer);
-        expect(dvo.name).toBe(dto.peer.substring(3, 9));
+        expect(dvo.name).toBe("i18n://dvo.identity.unknown");
         expect(dvo.description).toBe("i18n://dvo.relationship.Active");
         expect(dvo.type).toBe("IdentityDVO");
 
@@ -82,7 +82,7 @@ describe("RelationshipDVO", () => {
         const dvo = dvos[0];
         expect(dvo).toBeDefined();
         expect(dvo.id).toBe(dto.peer);
-        expect(dvo.name).toBe(dto.peer.substring(3, 9));
+        expect(dvo.name).toBe("i18n://dvo.identity.unknown");
         expect(dvo.description).toBe("i18n://dvo.relationship.Active");
         expect(dvo.type).toBe("IdentityDVO");
 

--- a/packages/runtime/test/dataViews/requestItems/CreateIdentityAttributeRequestItemDVO.test.ts
+++ b/packages/runtime/test/dataViews/requestItems/CreateIdentityAttributeRequestItemDVO.test.ts
@@ -216,7 +216,7 @@ describe("CreateIdentityAttributeRequestItemDVO", () => {
     test("check the sender's dvo for the recipient", async () => {
         const senderMessage = await exchangeAndAcceptRequestByMessage(sRuntimeServices, rRuntimeServices, requestContent, responseItems);
         const dvo = await rExpander.expandAddress(senderMessage.createdBy);
-        expect(dvo.name).toStrictEqual(senderMessage.createdBy.substring(3, 9));
+        expect(dvo.name).toBe("i18n://dvo.identity.unknown");
         expect(dvo.items).toHaveLength(0);
     });
 

--- a/packages/runtime/test/dataViews/requestItems/CreateRelationshipAttributeRequestItemDVO.test.ts
+++ b/packages/runtime/test/dataViews/requestItems/CreateRelationshipAttributeRequestItemDVO.test.ts
@@ -331,7 +331,7 @@ describe("CreateRelationshipAttributeRequestItemDVO", () => {
         const senderMessage = await exchangeAndAcceptRequestByMessage(sRuntimeServices, rRuntimeServices, requestContent, responseItems);
         const dvo = await sExpander.expandAddress(senderMessage.recipients[0].address);
 
-        expect(dvo.name).toStrictEqual(senderMessage.recipients[0].address.substring(3, 9));
+        expect(dvo.name).toBe("i18n://dvo.identity.unknown");
         expect(dvo.items).toHaveLength(0);
     });
 });

--- a/packages/runtime/test/dataViews/requestItems/DeleteAttributeRequestItemDVO.test.ts
+++ b/packages/runtime/test/dataViews/requestItems/DeleteAttributeRequestItemDVO.test.ts
@@ -252,7 +252,7 @@ describe("DeleteAttributeRequestItemDVO", () => {
         const senderMessage = await exchangeAndAcceptRequestByMessage(sRuntimeServices, rRuntimeServices, requestContent, responseItems);
         const dvo = await sExpander.expandAddress(senderMessage.recipients[0].address);
 
-        expect(dvo.name).toStrictEqual(senderMessage.recipients[0].address.substring(3, 9));
+        expect(dvo.name).toBe("i18n://dvo.identity.unknown");
         expect(dvo.items).toHaveLength(0);
     });
 });

--- a/packages/runtime/test/dataViews/requestItems/ShareAttributeRequestItemDVO.test.ts
+++ b/packages/runtime/test/dataViews/requestItems/ShareAttributeRequestItemDVO.test.ts
@@ -320,7 +320,7 @@ describe("ShareAttributeRequestItemDVO", () => {
         const senderMessage = await exchangeAndAcceptRequestByMessage(sRuntimeServices, rRuntimeServices, requestContent, responseItems);
         const dvo = await sExpander.expandAddress(senderMessage.recipients[0].address);
 
-        expect(dvo.name).toStrictEqual(senderMessage.recipients[0].address.substring(3, 9));
+        expect(dvo.name).toBe("i18n://dvo.identity.unknown");
         expect(dvo.items).toHaveLength(0);
     });
 });

--- a/packages/transport/package.json
+++ b/packages/transport/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nmshd/transport",
-    "version": "5.0.0-alpha.14",
+    "version": "5.0.0-alpha.15",
     "description": "The transport library handles backbone communication and content encryption.",
     "homepage": "https://enmeshed.eu",
     "repository": {


### PR DESCRIPTION
Unknown identities get assigned a "random" string which cannot be caught by the app. For example with `localhost` as hostname it's `:e:loc`.

This now assigns a safe, reproducable and processable string to these identities.