### PR TITLE
Fix/undo escape for urls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10734,7 +10734,7 @@
         },
         "packages/app-runtime": {
             "name": "@nmshd/app-runtime",
-            "version": "5.0.0-alpha.16",
+            "version": "5.0.0-alpha.17",
             "license": "MIT",
             "dependencies": {
                 "@js-soft/docdb-access-loki": "^1.1.0",
@@ -10748,12 +10748,12 @@
                 "@types/luxon": "^3.4.2"
             },
             "peerDependencies": {
-                "@nmshd/runtime": "^5.0.0-alpha.16"
+                "@nmshd/runtime": "^5.0.0-alpha.17"
             }
         },
         "packages/consumption": {
             "name": "@nmshd/consumption",
-            "version": "5.0.0-alpha.16",
+            "version": "5.0.0-alpha.17",
             "license": "MIT",
             "dependencies": {
                 "@js-soft/docdb-querytranslator": "^1.1.4",
@@ -10775,7 +10775,7 @@
         },
         "packages/content": {
             "name": "@nmshd/content",
-            "version": "5.0.0-alpha.16",
+            "version": "5.0.0-alpha.17",
             "license": "MIT",
             "dependencies": {
                 "@js-soft/logging-abstractions": "^1.0.1",
@@ -10800,17 +10800,17 @@
         },
         "packages/runtime": {
             "name": "@nmshd/runtime",
-            "version": "5.0.0-alpha.16",
+            "version": "5.0.0-alpha.17",
             "license": "MIT",
             "dependencies": {
                 "@js-soft/docdb-querytranslator": "^1.1.4",
                 "@js-soft/logging-abstractions": "^1.0.1",
                 "@js-soft/ts-serval": "2.0.10",
                 "@js-soft/ts-utils": "^2.3.3",
-                "@nmshd/consumption": "5.0.0-alpha.16",
-                "@nmshd/content": "5.0.0-alpha.16",
+                "@nmshd/consumption": "5.0.0-alpha.17",
+                "@nmshd/content": "5.0.0-alpha.17",
                 "@nmshd/crypto": "2.0.6",
-                "@nmshd/transport": "5.0.0-alpha.16",
+                "@nmshd/transport": "5.0.0-alpha.17",
                 "ajv": "^8.17.1",
                 "ajv-errors": "^3.0.0",
                 "ajv-formats": "^3.0.1",
@@ -10842,7 +10842,7 @@
         },
         "packages/transport": {
             "name": "@nmshd/transport",
-            "version": "5.0.0-alpha.16",
+            "version": "5.0.0-alpha.17",
             "license": "MIT",
             "dependencies": {
                 "@js-soft/docdb-access-abstractions": "1.0.4",

--- a/packages/app-runtime/package.json
+++ b/packages/app-runtime/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nmshd/app-runtime",
-    "version": "5.0.0-alpha.16",
+    "version": "5.0.0-alpha.17",
     "description": "The App Runtime",
     "homepage": "https://enmeshed.eu",
     "repository": {
@@ -63,7 +63,7 @@
         "@types/luxon": "^3.4.2"
     },
     "peerDependencies": {
-        "@nmshd/runtime": "^5.0.0-alpha.16"
+        "@nmshd/runtime": "^5.0.0-alpha.17"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/consumption/package.json
+++ b/packages/consumption/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nmshd/consumption",
-    "version": "5.0.0-alpha.16",
+    "version": "5.0.0-alpha.17",
     "description": "The consumption library extends the transport library.",
     "homepage": "https://enmeshed.eu",
     "repository": {

--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nmshd/content",
-    "version": "5.0.0-alpha.16",
+    "version": "5.0.0-alpha.17",
     "description": "The content library defines data structures that can be transmitted using the transport library.",
     "homepage": "https://enmeshed.eu",
     "repository": {

--- a/packages/content/src/attributes/types/strings/AbstractURL.ts
+++ b/packages/content/src/attributes/types/strings/AbstractURL.ts
@@ -19,7 +19,7 @@ export abstract class AbstractURL extends AbstractString {
         return super.valueHints.copyWith({
             min: 3,
             max: 1024,
-            pattern: AbstractURL.regExp.toString().slice(1, -1).replaceAll("/", "\\/")
+            pattern: AbstractURL.regExp.toString().slice(1, -1)
         });
     }
 

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nmshd/runtime",
-    "version": "5.0.0-alpha.16",
+    "version": "5.0.0-alpha.17",
     "description": "The enmeshed client runtime.",
     "homepage": "https://enmeshed.eu",
     "repository": {
@@ -65,10 +65,10 @@
         "@js-soft/logging-abstractions": "^1.0.1",
         "@js-soft/ts-serval": "2.0.10",
         "@js-soft/ts-utils": "^2.3.3",
-        "@nmshd/consumption": "5.0.0-alpha.16",
-        "@nmshd/content": "5.0.0-alpha.16",
+        "@nmshd/consumption": "5.0.0-alpha.17",
+        "@nmshd/content": "5.0.0-alpha.17",
         "@nmshd/crypto": "2.0.6",
-        "@nmshd/transport": "5.0.0-alpha.16",
+        "@nmshd/transport": "5.0.0-alpha.17",
         "ajv": "^8.17.1",
         "ajv-errors": "^3.0.0",
         "ajv-formats": "^3.0.1",

--- a/packages/transport/package.json
+++ b/packages/transport/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nmshd/transport",
-    "version": "5.0.0-alpha.16",
+    "version": "5.0.0-alpha.17",
     "description": "The transport library handles backbone communication and content encryption.",
     "homepage": "https://enmeshed.eu",
     "repository": {


### PR DESCRIPTION
It looks like URL was already correctly escaped. Reverts parts of #225 