### PR TITLE
Fix/Detach copies of child Attributes

### DIFF
--- a/packages/consumption/src/modules/attributes/AttributesController.ts
+++ b/packages/consumption/src/modules/attributes/AttributesController.ts
@@ -1039,7 +1039,8 @@ export class AttributesController extends ConsumptionBaseController {
         if (validationResult.isError()) throw validationResult.error;
 
         const childAttributes = await this.getLocalAttributes({ parentId: attribute.id.toString() });
-        for (const attr of [attribute, ...childAttributes]) {
+        const parentAndChildAttributes = [attribute, ...childAttributes];
+        for (const attr of parentAndChildAttributes) {
             if (attr.succeededBy) {
                 const successor = await this.getLocalAttribute(attr.succeededBy);
                 if (!successor) {
@@ -1049,9 +1050,15 @@ export class AttributesController extends ConsumptionBaseController {
             }
         }
 
-        const attributeCopies = await this.getLocalAttributes({ "shareInfo.sourceAttribute": attribute.id.toString() });
-        const attributePredecessorCopies = await this.getSharedPredecessorsOfAttribute(attribute);
-        const attributeCopiesToDetach = [...attributeCopies, ...attributePredecessorCopies];
+        const copiesOfParentAndChildAttributes = await this.getLocalAttributes({
+            ["shareInfo.sourceAttribute"]: { $in: parentAndChildAttributes.map((attribute) => attribute.id.toString()) }
+        });
+        const predecessorCopiesOfParentAndChildAttributes = [];
+        for (const attr of parentAndChildAttributes) {
+            const predecessorCopies = await this.getSharedPredecessorsOfAttribute(attr);
+            predecessorCopiesOfParentAndChildAttributes.push(...predecessorCopies);
+        }
+        const attributeCopiesToDetach = [...copiesOfParentAndChildAttributes, ...predecessorCopiesOfParentAndChildAttributes];
         await this.detachAttributeCopies(attributeCopiesToDetach);
 
         await this.deletePredecessorsOfAttribute(attribute.id);


### PR DESCRIPTION
I previously thought we didn't need this, since when sharing a complex Attribute no child copies are created. However, it is possible to also share child Attributes on their own and then when deleting the complex parent Attribute, these copies need to be detached, too.