### PR TITLE
Update app-runtime config value `dataFolder` to `databaseFolder` to align naming and actual usage

### DIFF
--- a/packages/app-runtime/src/AppConfig.ts
+++ b/packages/app-runtime/src/AppConfig.ts
@@ -7,7 +7,7 @@ export interface AppConfig extends RuntimeConfig {
     applicationId: string;
     applePushEnvironment?: "Development" | "Production";
     allowMultipleAccountsWithSameAddress: boolean;
-    dataFolder: string;
+    databaseFolder: string;
 }
 
 export interface AppConfigOverwrite {
@@ -16,7 +16,7 @@ export interface AppConfigOverwrite {
     applicationId: string;
     applePushEnvironment?: "Development" | "Production";
     allowMultipleAccountsWithSameAddress?: boolean;
-    dataFolder?: string;
+    databaseFolder?: string;
 }
 
 export function createAppConfig(...configs: AppConfigOverwrite[]): AppConfig {
@@ -96,7 +96,7 @@ export function createAppConfig(...configs: AppConfigOverwrite[]): AppConfig {
             }
         },
         allowMultipleAccountsWithSameAddress: false,
-        dataFolder: "./data"
+        databaseFolder: "./data"
     };
 
     const mergedConfig = defaultsDeep({}, ...configs, appConfig);

--- a/packages/app-runtime/src/AppRuntime.ts
+++ b/packages/app-runtime/src/AppRuntime.ts
@@ -282,7 +282,7 @@ export class AppRuntime extends Runtime<AppConfig> {
 
     protected createDatabaseConnection(): Promise<IDatabaseConnection> {
         this.logger.trace("Creating DatabaseConnection to LokiJS");
-        this.lokiConnection = new LokiJsConnection(this.config.dataFolder, this.nativeEnvironment.databaseFactory);
+        this.lokiConnection = new LokiJsConnection(this.config.databaseFolder, this.nativeEnvironment.databaseFactory);
         this.logger.trace("Finished initialization of LokiJS connection.");
 
         return Promise.resolve(this.lokiConnection);


### PR DESCRIPTION
# Readiness checklist

-   [ ] I added/updated tests.
-   [x] I ensured that the PR title is good enough for the changelog.
-   [x] I labeled the PR.
