### PR TITLE
Change the message of "error.consumption.validation.inheritedFromItem" when using canCreate

### DIFF
--- a/packages/consumption/src/consumption/ConsumptionCoreErrors.ts
+++ b/packages/consumption/src/consumption/ConsumptionCoreErrors.ts
@@ -306,6 +306,10 @@ class Requests {
         return new CoreError("error.consumption.requests.missingRelationship", message);
     }
 
+    public inheritedFromItem(message: string) {
+        return new ApplicationError("error.consumption.validation.inheritedFromItem", message);
+    }
+
     private static readonly _decideValidation = class {
         public invalidNumberOfItems(message: string) {
             return new ApplicationError("error.consumption.requests.decide.validation.invalidNumberOfItems", message);

--- a/packages/consumption/src/consumption/ConsumptionCoreErrors.ts
+++ b/packages/consumption/src/consumption/ConsumptionCoreErrors.ts
@@ -307,7 +307,7 @@ class Requests {
     }
 
     public inheritedFromItem(message: string) {
-        return new ApplicationError("error.consumption.validation.inheritedFromItem", message);
+        return new ApplicationError("error.consumption.requests.validation.inheritedFromItem", message);
     }
 
     private static readonly _decideValidation = class {

--- a/packages/consumption/src/modules/common/ValidationResult.ts
+++ b/packages/consumption/src/modules/common/ValidationResult.ts
@@ -21,9 +21,19 @@ export abstract class ValidationResult {
     }
 
     public static fromItems(items: ValidationResult[]): ValidationResult {
-        return items.some((r) => r.isError())
-            ? ValidationResult.error(ConsumptionCoreErrors.requests.inheritedFromItem("Some child items have errors."), items)
-            : ValidationResult.success(items);
+        if (items.some((r) => r.isError())) {
+            const receivedError = items.find((r) => r.isError());
+            if (typeof receivedError?.error.code !== "undefined") {
+                return ValidationResult.error(ConsumptionCoreErrors.requests.inheritedFromItem("Some child items have errors."), items);
+            }
+            return ValidationResult.error(
+                ConsumptionCoreErrors.requests.inheritedFromItem(
+                    "Some child items have errors. If this error occurred during the specification of a Request, call 'canCreate' to get more information."
+                ),
+                items
+            );
+        }
+        return ValidationResult.success(items);
     }
 }
 

--- a/packages/consumption/src/modules/common/ValidationResult.ts
+++ b/packages/consumption/src/modules/common/ValidationResult.ts
@@ -1,4 +1,5 @@
 import { ApplicationError } from "@js-soft/ts-utils";
+import { ConsumptionCoreErrors } from "../../consumption/ConsumptionCoreErrors";
 
 export abstract class ValidationResult {
     protected constructor(public readonly items: ValidationResult[]) {}
@@ -21,13 +22,7 @@ export abstract class ValidationResult {
 
     public static fromItems(items: ValidationResult[]): ValidationResult {
         return items.some((r) => r.isError())
-            ? ValidationResult.error(
-                  new ApplicationError(
-                      "error.consumption.validation.inheritedFromItem",
-                      "Some child items have errors. If this error occurred during the specification of a Request, call 'canCreate' to get more information."
-                  ),
-                  items
-              )
+            ? ValidationResult.error(ConsumptionCoreErrors.requests.inheritedFromItem("Some child items have errors."), items)
             : ValidationResult.success(items);
     }
 }

--- a/packages/consumption/src/modules/common/ValidationResult.ts
+++ b/packages/consumption/src/modules/common/ValidationResult.ts
@@ -21,19 +21,9 @@ export abstract class ValidationResult {
     }
 
     public static fromItems(items: ValidationResult[]): ValidationResult {
-        if (items.some((r) => r.isError())) {
-            const receivedError = items.find((r) => r.isError());
-            if (typeof receivedError?.error.code !== "undefined") {
-                return ValidationResult.error(ConsumptionCoreErrors.requests.inheritedFromItem("Some child items have errors."), items);
-            }
-            return ValidationResult.error(
-                ConsumptionCoreErrors.requests.inheritedFromItem(
-                    "Some child items have errors. If this error occurred during the specification of a Request, call 'canCreate' to get more information."
-                ),
-                items
-            );
-        }
-        return ValidationResult.success(items);
+        return items.some((r) => r.isError())
+            ? ValidationResult.error(ConsumptionCoreErrors.requests.inheritedFromItem("Some child items have errors."), items)
+            : ValidationResult.success(items);
     }
 }
 

--- a/packages/consumption/src/modules/requests/outgoing/OutgoingRequestsController.ts
+++ b/packages/consumption/src/modules/requests/outgoing/OutgoingRequestsController.ts
@@ -115,11 +115,7 @@ export class OutgoingRequestsController extends ConsumptionBaseController {
     private async _create(id: CoreId, content: Request, peer: CoreAddress) {
         const canCreateResult = await this.canCreate({ content, peer });
 
-        if (canCreateResult.isError()) {
-            throw ConsumptionCoreErrors.requests.inheritedFromItem(
-                "Some child items have errors. If this error occurred during the specification of a Request, call 'canCreate' to get more information."
-            );
-        }
+        if (canCreateResult.isError()) throw canCreateResult.error;
 
         const request = LocalRequest.from({
             id: id,

--- a/packages/consumption/src/modules/requests/outgoing/OutgoingRequestsController.ts
+++ b/packages/consumption/src/modules/requests/outgoing/OutgoingRequestsController.ts
@@ -115,7 +115,15 @@ export class OutgoingRequestsController extends ConsumptionBaseController {
     private async _create(id: CoreId, content: Request, peer: CoreAddress) {
         const canCreateResult = await this.canCreate({ content, peer });
 
-        if (canCreateResult.isError()) throw canCreateResult.error;
+        if (canCreateResult.isError()) {
+            if (canCreateResult.error.code === "error.consumption.validation.inheritedFromItem") {
+                throw ConsumptionCoreErrors.requests.inheritedFromItem(
+                    "Some child items have errors. If this error occurred during the specification of a Request, call 'canCreate' to get more information."
+                );
+            }
+
+            throw canCreateResult.error;
+        }
 
         const request = LocalRequest.from({
             id: id,

--- a/packages/consumption/src/modules/requests/outgoing/OutgoingRequestsController.ts
+++ b/packages/consumption/src/modules/requests/outgoing/OutgoingRequestsController.ts
@@ -118,6 +118,7 @@ export class OutgoingRequestsController extends ConsumptionBaseController {
         if (canCreateResult.isError()) {
             const error = ConsumptionCoreErrors.requests.inheritedFromItem("Some child items have errors. Call 'canCreate' to get more information.");
             if (canCreateResult.error.equals(error)) throw error;
+
             throw canCreateResult.error;
         }
 

--- a/packages/consumption/src/modules/requests/outgoing/OutgoingRequestsController.ts
+++ b/packages/consumption/src/modules/requests/outgoing/OutgoingRequestsController.ts
@@ -115,7 +115,11 @@ export class OutgoingRequestsController extends ConsumptionBaseController {
     private async _create(id: CoreId, content: Request, peer: CoreAddress) {
         const canCreateResult = await this.canCreate({ content, peer });
 
-        if (canCreateResult.isError()) throw canCreateResult.error;
+        if (canCreateResult.isError()) {
+            throw ConsumptionCoreErrors.requests.inheritedFromItem(
+                "Some child items have errors. If this error occurred during the specification of a Request, call 'canCreate' to get more information."
+            );
+        }
 
         const request = LocalRequest.from({
             id: id,

--- a/packages/consumption/src/modules/requests/outgoing/OutgoingRequestsController.ts
+++ b/packages/consumption/src/modules/requests/outgoing/OutgoingRequestsController.ts
@@ -116,12 +116,8 @@ export class OutgoingRequestsController extends ConsumptionBaseController {
         const canCreateResult = await this.canCreate({ content, peer });
 
         if (canCreateResult.isError()) {
-            if (canCreateResult.error.code === "error.consumption.validation.inheritedFromItem") {
-                throw ConsumptionCoreErrors.requests.inheritedFromItem(
-                    "Some child items have errors. If this error occurred during the specification of a Request, call 'canCreate' to get more information."
-                );
-            }
-
+            const error = ConsumptionCoreErrors.requests.inheritedFromItem("Some child items have errors. Call 'canCreate' to get more information.");
+            if (canCreateResult.error.equals(error)) throw error;
             throw canCreateResult.error;
         }
 

--- a/packages/consumption/test/modules/requests/DecideRequestParametersValidator.test.ts
+++ b/packages/consumption/test/modules/requests/DecideRequestParametersValidator.test.ts
@@ -273,7 +273,7 @@ describe("DecideRequestParametersValidator", function () {
             expectedError: {
                 indexPath: [0],
                 code: "error.consumption.validation.inheritedFromItem",
-                message: "Some child items have errors. If this error occurred during the specification of a Request, call 'canCreate' to get more information."
+                message: "Some child items have errors."
             }
         }
     ];

--- a/packages/consumption/test/modules/requests/DecideRequestParametersValidator.test.ts
+++ b/packages/consumption/test/modules/requests/DecideRequestParametersValidator.test.ts
@@ -272,7 +272,7 @@ describe("DecideRequestParametersValidator", function () {
             },
             expectedError: {
                 indexPath: [0],
-                code: "error.consumption.validation.inheritedFromItem",
+                code: "error.consumption.requests.validation.inheritedFromItem",
                 message: "Some child items have errors."
             }
         }
@@ -317,7 +317,7 @@ describe("DecideRequestParametersValidator", function () {
         }
 
         expect(validationResult).errorValidationResult({
-            code: "error.consumption.validation.inheritedFromItem"
+            code: "error.consumption.requests.validation.inheritedFromItem"
         });
 
         let childResult = validationResult;

--- a/packages/consumption/test/modules/requests/IncomingRequestsController.test.ts
+++ b/packages/consumption/test/modules/requests/IncomingRequestsController.test.ts
@@ -365,7 +365,7 @@ describe("IncomingRequestsController", function () {
 
             expect(validationResult).errorValidationResult({
                 code: "error.consumption.validation.inheritedFromItem",
-                message: "Some child items have errors. If this error occurred during the specification of a Request, call 'canCreate' to get more information."
+                message: "Some child items have errors."
             });
             expect(validationResult.items).toHaveLength(2);
 
@@ -559,7 +559,7 @@ describe("IncomingRequestsController", function () {
 
             expect(validationResult).errorValidationResult({
                 code: "error.consumption.validation.inheritedFromItem",
-                message: "Some child items have errors. If this error occurred during the specification of a Request, call 'canCreate' to get more information."
+                message: "Some child items have errors."
             });
             expect(validationResult.items).toHaveLength(2);
 

--- a/packages/consumption/test/modules/requests/IncomingRequestsController.test.ts
+++ b/packages/consumption/test/modules/requests/IncomingRequestsController.test.ts
@@ -364,7 +364,7 @@ describe("IncomingRequestsController", function () {
             });
 
             expect(validationResult).errorValidationResult({
-                code: "error.consumption.validation.inheritedFromItem",
+                code: "error.consumption.requests.validation.inheritedFromItem",
                 message: "Some child items have errors."
             });
             expect(validationResult.items).toHaveLength(2);
@@ -372,7 +372,7 @@ describe("IncomingRequestsController", function () {
             expect(validationResult.items[0].isError()).toBe(false);
 
             expect(validationResult.items[1].isError()).toBe(true);
-            expect(validationResult.items[1]).errorValidationResult({ code: "error.consumption.validation.inheritedFromItem" });
+            expect(validationResult.items[1]).errorValidationResult({ code: "error.consumption.requests.validation.inheritedFromItem" });
 
             expect(validationResult.items[1].items).toHaveLength(3);
             expect(validationResult.items[1].items[0].isError()).toBe(true);
@@ -558,7 +558,7 @@ describe("IncomingRequestsController", function () {
             const validationResult = await When.iCallCanRejectWith(rejectParams);
 
             expect(validationResult).errorValidationResult({
-                code: "error.consumption.validation.inheritedFromItem",
+                code: "error.consumption.requests.validation.inheritedFromItem",
                 message: "Some child items have errors."
             });
             expect(validationResult.items).toHaveLength(2);
@@ -566,7 +566,7 @@ describe("IncomingRequestsController", function () {
             expect(validationResult.items[0].isError()).toBe(false);
 
             expect(validationResult.items[1].isError()).toBe(true);
-            expect(validationResult.items[1]).errorValidationResult({ code: "error.consumption.validation.inheritedFromItem" });
+            expect(validationResult.items[1]).errorValidationResult({ code: "error.consumption.requests.validation.inheritedFromItem" });
 
             expect(validationResult.items[1].items).toHaveLength(3);
             expect(validationResult.items[1].items[0].isError()).toBe(true);

--- a/packages/consumption/test/modules/requests/OutgoingRequestsController.test.ts
+++ b/packages/consumption/test/modules/requests/OutgoingRequestsController.test.ts
@@ -151,7 +151,7 @@ describe("OutgoingRequestsController", function () {
                 }
             });
             expect(validationResult).errorValidationResult({
-                code: "error.consumption.validation.inheritedFromItem",
+                code: "error.consumption.requests.validation.inheritedFromItem",
                 message: "Some child items have errors."
             });
             expect(validationResult.items).toHaveLength(2);
@@ -184,7 +184,7 @@ describe("OutgoingRequestsController", function () {
                 }
             });
             expect(validationResult).errorValidationResult({
-                code: "error.consumption.validation.inheritedFromItem",
+                code: "error.consumption.requests.validation.inheritedFromItem",
                 message: "Some child items have errors."
             });
             expect(validationResult.items).toHaveLength(2);
@@ -192,7 +192,7 @@ describe("OutgoingRequestsController", function () {
             expect(validationResult.items[0].isError()).toBe(false);
 
             expect(validationResult.items[1].isError()).toBe(true);
-            expect((validationResult.items[1] as ErrorValidationResult).error.code).toBe("error.consumption.validation.inheritedFromItem");
+            expect((validationResult.items[1] as ErrorValidationResult).error.code).toBe("error.consumption.requests.validation.inheritedFromItem");
             expect((validationResult.items[1] as ErrorValidationResult).error.message).toBe("Some child items have errors.");
 
             expect(validationResult.items[1].items).toHaveLength(1);
@@ -227,9 +227,7 @@ describe("OutgoingRequestsController", function () {
 
         test("throws that it is necessary to call 'canCreate' when at least one RequestItem is invalid", async function () {
             await When.iTryToCreateAnOutgoingRequestWithIncorrectRequestItem();
-            await Then.itThrowsAnErrorWithTheErrorMessage(
-                "Some child items have errors. If this error occurred during the specification of a Request, call 'canCreate' to get more information."
-            );
+            await Then.itThrowsAnErrorWithTheErrorMessage("Some child items have errors. Call 'canCreate' to get more information.");
         });
 
         test("throws when canCreate returns an error", async function () {

--- a/packages/consumption/test/modules/requests/OutgoingRequestsController.test.ts
+++ b/packages/consumption/test/modules/requests/OutgoingRequestsController.test.ts
@@ -225,6 +225,13 @@ describe("OutgoingRequestsController", function () {
             await Then.itThrowsAnErrorWithTheErrorMessage("*content*Value is not defined*");
         });
 
+        test("throws that it is necessary to call 'canCreate' when at least one RequestItem is invalid", async function () {
+            await When.iTryToCreateAnOutgoingRequestWithIncorrectRequestItem();
+            await Then.itThrowsAnErrorWithTheErrorMessage(
+                "Some child items have errors. If this error occurred during the specification of a Request, call 'canCreate' to get more information."
+            );
+        });
+
         test("throws when canCreate returns an error", async function () {
             const oldCanCreate = context.outgoingRequestsController.canCreate;
             context.outgoingRequestsController.canCreate = (_: ICreateOutgoingRequestParameters) => {

--- a/packages/consumption/test/modules/requests/OutgoingRequestsController.test.ts
+++ b/packages/consumption/test/modules/requests/OutgoingRequestsController.test.ts
@@ -228,14 +228,7 @@ describe("OutgoingRequestsController", function () {
         test("throws when canCreate returns an error", async function () {
             const oldCanCreate = context.outgoingRequestsController.canCreate;
             context.outgoingRequestsController.canCreate = (_: ICreateOutgoingRequestParameters) => {
-                return Promise.resolve(
-                    ValidationResult.error(
-                        new ApplicationError(
-                            "error.consumption.validation.inheritedFromItem",
-                            "Some child items have errors. If this error occurred during the specification of a Request, call 'canCreate' to get more information."
-                        )
-                    )
-                );
+                return Promise.resolve(ValidationResult.error(new ApplicationError("aCode", "aMessage")));
             };
 
             await When.iTryToCreateAnOutgoingRequest();

--- a/packages/consumption/test/modules/requests/OutgoingRequestsController.test.ts
+++ b/packages/consumption/test/modules/requests/OutgoingRequestsController.test.ts
@@ -232,9 +232,7 @@ describe("OutgoingRequestsController", function () {
             };
 
             await When.iTryToCreateAnOutgoingRequest();
-            await Then.itThrowsAnErrorWithTheErrorMessage(
-                "Some child items have errors. If this error occurred during the specification of a Request, call 'canCreate' to get more information."
-            );
+            await Then.itThrowsAnErrorWithTheErrorMessage("aMessage");
 
             context.outgoingRequestsController.canCreate = oldCanCreate;
         });

--- a/packages/consumption/test/modules/requests/OutgoingRequestsController.test.ts
+++ b/packages/consumption/test/modules/requests/OutgoingRequestsController.test.ts
@@ -152,7 +152,7 @@ describe("OutgoingRequestsController", function () {
             });
             expect(validationResult).errorValidationResult({
                 code: "error.consumption.validation.inheritedFromItem",
-                message: "Some child items have errors. If this error occurred during the specification of a Request, call 'canCreate' to get more information."
+                message: "Some child items have errors."
             });
             expect(validationResult.items).toHaveLength(2);
 
@@ -185,7 +185,7 @@ describe("OutgoingRequestsController", function () {
             });
             expect(validationResult).errorValidationResult({
                 code: "error.consumption.validation.inheritedFromItem",
-                message: "Some child items have errors. If this error occurred during the specification of a Request, call 'canCreate' to get more information."
+                message: "Some child items have errors."
             });
             expect(validationResult.items).toHaveLength(2);
 
@@ -193,9 +193,7 @@ describe("OutgoingRequestsController", function () {
 
             expect(validationResult.items[1].isError()).toBe(true);
             expect((validationResult.items[1] as ErrorValidationResult).error.code).toBe("error.consumption.validation.inheritedFromItem");
-            expect((validationResult.items[1] as ErrorValidationResult).error.message).toBe(
-                "Some child items have errors. If this error occurred during the specification of a Request, call 'canCreate' to get more information."
-            );
+            expect((validationResult.items[1] as ErrorValidationResult).error.message).toBe("Some child items have errors.");
 
             expect(validationResult.items[1].items).toHaveLength(1);
             expect(validationResult.items[1].items[0].isError()).toBe(true);
@@ -230,11 +228,20 @@ describe("OutgoingRequestsController", function () {
         test("throws when canCreate returns an error", async function () {
             const oldCanCreate = context.outgoingRequestsController.canCreate;
             context.outgoingRequestsController.canCreate = (_: ICreateOutgoingRequestParameters) => {
-                return Promise.resolve(ValidationResult.error(new ApplicationError("aCode", "aMessage")));
+                return Promise.resolve(
+                    ValidationResult.error(
+                        new ApplicationError(
+                            "error.consumption.validation.inheritedFromItem",
+                            "Some child items have errors. If this error occurred during the specification of a Request, call 'canCreate' to get more information."
+                        )
+                    )
+                );
             };
 
             await When.iTryToCreateAnOutgoingRequest();
-            await Then.itThrowsAnErrorWithTheErrorMessage("aMessage");
+            await Then.itThrowsAnErrorWithTheErrorMessage(
+                "Some child items have errors. If this error occurred during the specification of a Request, call 'canCreate' to get more information."
+            );
 
             context.outgoingRequestsController.canCreate = oldCanCreate;
         });

--- a/packages/consumption/test/modules/requests/RequestsIntegrationTest.ts
+++ b/packages/consumption/test/modules/requests/RequestsIntegrationTest.ts
@@ -936,6 +936,30 @@ export class RequestsWhen {
         return Promise.resolve();
     }
 
+    public iTryToCreateAnOutgoingRequestWithIncorrectRequestItem(): Promise<void> {
+        const params: ICreateOutgoingRequestParameters = {
+            content: {
+                items: [
+                    TestRequestItem.from({
+                        mustBeAccepted: false,
+                        shouldFailAtCanCreateOutgoingRequestItem: true
+                    }),
+                    TestRequestItem.from({
+                        mustBeAccepted: false,
+                        shouldFailAtCanCreateOutgoingRequestItem: true
+                    })
+                ]
+            },
+            peer: CoreAddress.from("did:e:a-domain:dids:anidentity")
+        };
+
+        this.context.actionToTry = async () => {
+            await this.context.outgoingRequestsController.create(params as any);
+        };
+
+        return Promise.resolve();
+    }
+
     public iTryToCreateAnOutgoingRequestFromRelationshipTemplateResponseWithoutResponseSource(): Promise<void> {
         const paramsWithoutResponseSource: Omit<ICreateAndCompleteOutgoingRequestFromRelationshipTemplateResponseParameters, "responseSource"> = {
             response: TestObjectFactory.createResponse(),

--- a/packages/runtime/test/modules/DeciderModule.test.ts
+++ b/packages/runtime/test/modules/DeciderModule.test.ts
@@ -123,35 +123,4 @@ describe("DeciderModule", () => {
             (e) => e.data.template.id === template.id && e.data.result === RelationshipTemplateProcessedResult.ManualRequestDecisionRequired
         );
     });
-
-    test("if you call canCreate for a request with an item which has an error you receive another errorMessage as if you call create", async () => {
-        const requestContent = {
-            content: {
-                items: [
-                    {
-                        "@type": "ShareAttributeRequestItem",
-                        sourceAttributeId: "ATT",
-                        attribute: {
-                            "@type": "IdentityAttribute",
-                            owner: (await sender.transport.account.getIdentityInfo()).value.address,
-                            value: {
-                                "@type": "GivenName",
-                                value: "aGivenName"
-                            }
-                        },
-                        mustBeAccepted: true
-                    }
-                ]
-            },
-            peer: (await recipient.transport.account.getIdentityInfo()).value.address
-        };
-        const canCreateResult = await sender.consumption.outgoingRequests.canCreate(requestContent);
-        const createResult = await sender.consumption.outgoingRequests.create(requestContent);
-        expect(createResult.error.code).toBe("error.consumption.validation.inheritedFromItem");
-        expect(createResult.error.message).toBe(
-            "Some child items have errors. If this error occurred during the specification of a Request, call 'canCreate' to get more information."
-        );
-        expect(canCreateResult.value.code).toBe("error.consumption.validation.inheritedFromItem");
-        expect(canCreateResult.value.message).toBe("Some child items have errors.");
-    });
 });


### PR DESCRIPTION
# Readiness checklist

-   [X] I added/updated tests.
-   [X] I ensured that the PR title is good enough for the changelog.
-   [X] I labeled the PR.
