### PR TITLE
Make relationship setting usable

### DIFF
--- a/packages/runtime/src/dataViews/DataViewExpander.ts
+++ b/packages/runtime/src/dataViews/DataViewExpander.ts
@@ -1804,7 +1804,8 @@ export class DataViewExpander {
 
         if (settingResult.value.length === 0) return defaultSetting;
 
-        const value = settingResult.value.reduce((prev, current) => (prev.createdAt > current.createdAt ? prev : current));
+        const latestSetting = settingResult.value.reduce((prev, current) => (prev.createdAt > current.createdAt ? prev : current));
+        const value = latestSetting.value;
 
         if (typeof value !== "object") return defaultSetting;
 

--- a/packages/runtime/src/dataViews/DataViewExpander.ts
+++ b/packages/runtime/src/dataViews/DataViewExpander.ts
@@ -1773,6 +1773,7 @@ export class DataViewExpander {
         return {
             id: relationship.id,
             name: relationshipSetting.userTitle ?? name,
+            originalName: relationshipSetting.userTitle ? name : undefined,
             description: relationshipSetting.userDescription ?? statusText,
             date: creationDate,
             image: "",
@@ -1818,6 +1819,7 @@ export class DataViewExpander {
             type: "IdentityDVO",
             id: relationship.peer,
             name: relationshipDVO.name,
+            originalName: relationshipDVO.originalName,
             date: relationshipDVO.date,
             description: relationshipDVO.description,
             publicKey: relationship.peerIdentity.publicKey,

--- a/packages/runtime/src/dataViews/transport/IdentityDVO.ts
+++ b/packages/runtime/src/dataViews/transport/IdentityDVO.ts
@@ -9,4 +9,5 @@ export interface IdentityDVO extends DataViewObject {
     isSelf: boolean;
     hasRelationship: boolean;
     relationship?: RelationshipDVO;
+    originalName?: string;
 }

--- a/packages/runtime/src/dataViews/transport/RelationshipDVO.ts
+++ b/packages/runtime/src/dataViews/transport/RelationshipDVO.ts
@@ -21,6 +21,7 @@ export interface RelationshipDVO extends DataViewObject {
     attributeMap: Record<string, undefined | LocalAttributeDVO[]>;
     nameMap: Record<string, undefined | string>;
     templateId: string;
+    originalName?: string;
 }
 
 export interface RelationshipTheme {

--- a/packages/runtime/src/useCases/common/Schemas.ts
+++ b/packages/runtime/src/useCases/common/Schemas.ts
@@ -20302,6 +20302,17 @@ export const GetSettingByKeyRequest: any = {
             "properties": {
                 "key": {
                     "type": "string"
+                },
+                "reference": {
+                    "type": "string"
+                },
+                "scope": {
+                    "type": "string",
+                    "enum": [
+                        "Identity",
+                        "Device",
+                        "Relationship"
+                    ]
                 }
             },
             "required": [
@@ -20447,13 +20458,28 @@ export const UpsertSettingByKeyRequest: any = {
                 "key": {
                     "type": "string"
                 },
-                "value": {}
+                "value": {},
+                "reference": {
+                    "$ref": "#/definitions/GenericIdString"
+                },
+                "scope": {
+                    "type": "string",
+                    "enum": [
+                        "Identity",
+                        "Device",
+                        "Relationship"
+                    ]
+                }
             },
             "required": [
                 "key",
                 "value"
             ],
             "additionalProperties": false
+        },
+        "GenericIdString": {
+            "type": "string",
+            "pattern": "[A-Za-z0-9]{20}"
         }
     }
 }

--- a/packages/runtime/src/useCases/consumption/settings/GetSettingByKey.ts
+++ b/packages/runtime/src/useCases/consumption/settings/GetSettingByKey.ts
@@ -1,5 +1,5 @@
 import { Result } from "@js-soft/ts-utils";
-import { Setting, SettingsController } from "@nmshd/consumption";
+import { Setting, SettingsController, SettingScope } from "@nmshd/consumption";
 import { Inject } from "typescript-ioc";
 import { SettingDTO } from "../../../types";
 import { RuntimeErrors, SchemaRepository, SchemaValidator, UseCase } from "../../common";
@@ -26,11 +26,13 @@ export class GetSettingByKeyUseCase extends UseCase<GetSettingByKeyRequest, Sett
     }
 
     protected async executeInternal(request: GetSettingByKeyRequest): Promise<Result<SettingDTO>> {
-        const settings = await this.settingController.getSettings({
+        const query = {
             key: request.key,
-            reference: request.reference,
-            scope: request.scope
-        });
+            reference: request.reference ?? { $exists: false },
+            scope: request.scope ?? SettingScope.Identity
+        };
+
+        const settings = await this.settingController.getSettings(query);
         if (settings.length === 0) {
             return Result.fail(RuntimeErrors.general.recordNotFound(Setting));
         }

--- a/packages/runtime/src/useCases/consumption/settings/GetSettingByKey.ts
+++ b/packages/runtime/src/useCases/consumption/settings/GetSettingByKey.ts
@@ -7,6 +7,8 @@ import { SettingMapper } from "./SettingMapper";
 
 export interface GetSettingByKeyRequest {
     key: string;
+    reference?: string;
+    scope?: "Identity" | "Device" | "Relationship";
 }
 
 class Validator extends SchemaValidator<GetSettingByKeyRequest> {
@@ -24,7 +26,11 @@ export class GetSettingByKeyUseCase extends UseCase<GetSettingByKeyRequest, Sett
     }
 
     protected async executeInternal(request: GetSettingByKeyRequest): Promise<Result<SettingDTO>> {
-        const settings = await this.settingController.getSettings({ key: request.key });
+        const settings = await this.settingController.getSettings({
+            key: request.key,
+            reference: request.reference,
+            scope: request.scope
+        });
         if (settings.length === 0) {
             return Result.fail(RuntimeErrors.general.recordNotFound(Setting));
         }

--- a/packages/runtime/src/useCases/consumption/settings/UpsertSettingByKey.ts
+++ b/packages/runtime/src/useCases/consumption/settings/UpsertSettingByKey.ts
@@ -33,8 +33,8 @@ export class UpsertSettingByKeyUseCase extends UseCase<UpsertSettingByKeyRequest
     protected async executeInternal(request: UpsertSettingByKeyRequest): Promise<Result<SettingDTO>> {
         const settings = await this.settingController.getSettings({
             key: request.key,
-            reference: request.reference,
-            scope: request.scope
+            reference: request.reference ?? { $exists: false },
+            scope: request.scope ?? SettingScope.Identity
         });
 
         const newValue = Serializable.fromUnknown(request.value);

--- a/packages/runtime/test/consumption/settings.test.ts
+++ b/packages/runtime/test/consumption/settings.test.ts
@@ -146,6 +146,7 @@ describe("Settings", () => {
 
         const result = await consumptionServices.settings.getSettingByKey({ key, reference, scope });
         expect(result).toBeSuccessful();
+        expect(result.value.value).toStrictEqual(value);
     });
 });
 

--- a/packages/runtime/test/consumption/settings.test.ts
+++ b/packages/runtime/test/consumption/settings.test.ts
@@ -134,6 +134,19 @@ describe("Settings", () => {
         const setting = await consumptionServices.settings.getSettingByKey({ key: "a-key" });
         expect(setting.value.value).toStrictEqual({ aKey: "aNewValue" });
     });
+
+    test("should get the settings by key including a reference and type", async () => {
+        const key = "a-key";
+        const value = { aKey: "a-value" };
+        const reference = (await TransportIds.generic.generate()).toString();
+        const scope = "Identity";
+
+        const upsertSettingResult = await consumptionServices.settings.upsertSettingByKey({ key, reference, scope, value });
+        expect(upsertSettingResult).toBeSuccessful();
+
+        const result = await consumptionServices.settings.getSettingByKey({ key, reference, scope });
+        expect(result).toBeSuccessful();
+    });
 });
 
 describe("Settings query", () => {

--- a/packages/runtime/test/dataViews/RelationshipDVO.test.ts
+++ b/packages/runtime/test/dataViews/RelationshipDVO.test.ts
@@ -103,7 +103,7 @@ describe("RelationshipDVO", () => {
         expect(dvo.relationship!.templateId).toBe(dto.template.id);
     });
 
-    test("check the relationship dvo for the templator wit active relationshipSetting", async () => {
+    test("check the relationship dvo for the templator with active relationshipSetting", async () => {
         const dtos = (await runtimeServices1.transport.relationships.getRelationships({})).value;
         const dto = dtos[0];
 


### PR DESCRIPTION
# Readiness checklist

-   [x] I added/updated tests.
-   [x] I ensured that the PR title is good enough for the changelog.
-   [x] I labeled the PR.

# Description

As the App wants to be able to override names for contacts we have to update the functionality that @stnmtz build with new possibilities from the settings module, to be usable again.

As it is also a requirement to revert the contact name to the runtime default I also return the original name.
