### PR TITLE
ShareAttributeRequestItemDVOs `attribute.id` is overridden with with `undefined`

### DIFF
--- a/packages/runtime/src/dataViews/DataViewExpander.ts
+++ b/packages/runtime/src/dataViews/DataViewExpander.ts
@@ -660,11 +660,13 @@ export class DataViewExpander {
                         response: responseItemDVO
                     } as DecidableShareAttributeRequestItemDVO;
                 }
-                // We have to manually copy the attribute id here, otherwise we could not link to the local attribute
-                const shareAttributeResponseItem = responseItemDVO as ShareAttributeAcceptResponseItemDVO | undefined;
-                if (shareAttributeResponseItem) {
-                    attributeDVO.id = shareAttributeResponseItem.attributeId;
+
+                if (responseItemDVO?.result === ResponseItemResult.Accepted) {
+                    // We have to manually copy the attribute id here, otherwise we could not link to the local attribute
+                    const shareAttributeResponseItem = responseItemDVO as ShareAttributeAcceptResponseItemDVO | undefined;
+                    if (shareAttributeResponseItem) attributeDVO.id = shareAttributeResponseItem.attributeId;
                 }
+
                 return {
                     ...shareAttributeRequestItem,
                     type: "ShareAttributeRequestItemDVO",


### PR DESCRIPTION
# Readiness checklist

-   [ ] I added/updated tests.
-   [x] I ensured that the PR title is good enough for the changelog.
-   [x] I labeled the PR.

# Description

Unsafe `as X` casting destroyed the ShareAttributeRequestItemDVO when the item was rejected.