### PR TITLE
Bump Node.js version in pipelines

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: current
           registry-url: https://registry.npmjs.org/
       - run: npm ci
       - run: npm run build:ci -ws

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
         run: npm run start:backbone
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: current
       - run: npm ci
       - run: npm run build:node
       - run: npm run test:ci --workspace=@nmshd/app-runtime
@@ -46,7 +46,7 @@ jobs:
         run: npm run start:backbone
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: current
       - run: npm ci
       - name: Start MongoDB
         uses: supercharge/mongodb-github-action@v1
@@ -66,7 +66,7 @@ jobs:
         run: npm run start:backbone
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: current
       - run: npm ci
       - uses: js-soft/ferretdb-github-action@1.1.1
         with:
@@ -88,7 +88,7 @@ jobs:
         run: npm run start:backbone
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: current
       - run: npm ci
       - run: npm run build:node
       - run: npm run test:ci:lokijs --workspace=@nmshd/consumption
@@ -108,7 +108,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: current
       - run: npm ci
       - run: npm run build:node
       - run: npm run test:ci --workspace=@nmshd/content
@@ -124,7 +124,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: current
       - run: npm ci
       - run: npm run build:node
       - run: npm run test:ci --workspace=@nmshd/core-types
@@ -142,7 +142,7 @@ jobs:
         run: npm run start:backbone
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: current
       - uses: supercharge/mongodb-github-action@v1
       - run: npm ci
       - run: npm run build:node
@@ -163,7 +163,7 @@ jobs:
         run: npm run start:backbone
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: current
       - uses: js-soft/ferretdb-github-action@1.1.1
         with:
           ferretdb-telemetry: "enabled"
@@ -187,7 +187,7 @@ jobs:
         run: npm run start:backbone
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: current
       - run: npm ci
       - run: npm run build:node
       - run: npm run build:schemas --workspace=@nmshd/runtime
@@ -211,7 +211,7 @@ jobs:
         run: npm run start:backbone
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: current
       - run: npm ci
       - run: npm run build:node
       - name: Start MongoDB
@@ -232,7 +232,7 @@ jobs:
         run: npm run start:backbone
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: current
       - run: npm ci
       - run: npm run build:node
       - uses: js-soft/ferretdb-github-action@1.1.1
@@ -255,7 +255,7 @@ jobs:
         run: npm run start:backbone
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: current
       - run: npm ci
       - run: npm run build:node
       - run: npm run test:ci:lokijs --workspace=@nmshd/transport


### PR DESCRIPTION
# Readiness checklist

-   [ ] I added/updated tests.
-   [x] I ensured that the PR title is good enough for the changelog.
-   [x] I labeled the PR.

# Description

As the [publish issues with node 23 are now fixed](https://github.com/npm/cli/issues/7853#issuecomment-2443991430) when using Node.js `>=23.1.0` and [the connector is bumped to node 23](https://github.com/nmshd/connector/pull/298) we should make sure our libs are working on this version.

Therefore all pipelines are bumped to node current again.