### PR TITLE
Make `creationContent` parameter of CanCreateRelationshipUseCase optional

### DIFF
--- a/packages/runtime/src/extensibility/facades/transport/RelationshipsFacade.ts
+++ b/packages/runtime/src/extensibility/facades/transport/RelationshipsFacade.ts
@@ -32,7 +32,7 @@ import {
     TerminateRelationshipRequest,
     TerminateRelationshipUseCase
 } from "../../../useCases";
-import { CanCreateRelationshipResponse, CanCreateRelationshipUseCase } from "../../../useCases/transport/relationships/CanCreateRelationship";
+import { CanCreateRelationshipRequest, CanCreateRelationshipResponse, CanCreateRelationshipUseCase } from "../../../useCases/transport/relationships/CanCreateRelationship";
 
 export class RelationshipsFacade {
     public constructor(
@@ -65,7 +65,7 @@ export class RelationshipsFacade {
         return await this.getRelationshipByAddressUseCase.execute(request);
     }
 
-    public async canCreateRelationship(request: CreateRelationshipRequest): Promise<Result<CanCreateRelationshipResponse>> {
+    public async canCreateRelationship(request: CanCreateRelationshipRequest): Promise<Result<CanCreateRelationshipResponse>> {
         return await this.canCreateRelationshipUseCase.execute(request);
     }
 

--- a/packages/runtime/src/extensibility/facades/transport/RelationshipsFacade.ts
+++ b/packages/runtime/src/extensibility/facades/transport/RelationshipsFacade.ts
@@ -6,6 +6,9 @@ import {
     AcceptRelationshipReactivationUseCase,
     AcceptRelationshipRequest,
     AcceptRelationshipUseCase,
+    CanCreateRelationshipRequest,
+    CanCreateRelationshipResponse,
+    CanCreateRelationshipUseCase,
     CreateRelationshipRequest,
     CreateRelationshipUseCase,
     DecomposeRelationshipRequest,
@@ -32,7 +35,6 @@ import {
     TerminateRelationshipRequest,
     TerminateRelationshipUseCase
 } from "../../../useCases";
-import { CanCreateRelationshipRequest, CanCreateRelationshipResponse, CanCreateRelationshipUseCase } from "../../../useCases/transport/relationships/CanCreateRelationship";
 
 export class RelationshipsFacade {
     public constructor(

--- a/packages/runtime/src/useCases/common/Schemas.ts
+++ b/packages/runtime/src/useCases/common/Schemas.ts
@@ -22896,3 +22896,27 @@ export const LoadPeerTokenRequest: any = {
         }
     }
 }
+
+export const CanCreateRelationshipRequest: any = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$ref": "#/definitions/CanCreateRelationshipRequest",
+    "definitions": {
+        "CanCreateRelationshipRequest": {
+            "type": "object",
+            "properties": {
+                "templateId": {
+                    "$ref": "#/definitions/RelationshipTemplateIdString"
+                },
+                "creationContent": {}
+            },
+            "required": [
+                "templateId"
+            ],
+            "additionalProperties": false
+        },
+        "RelationshipTemplateIdString": {
+            "type": "string",
+            "pattern": "RLT[A-Za-z0-9]{17}"
+        }
+    }
+}

--- a/packages/runtime/src/useCases/transport/relationships/CanCreateRelationship.ts
+++ b/packages/runtime/src/useCases/transport/relationships/CanCreateRelationship.ts
@@ -29,9 +29,10 @@ export type CanCreateRelationshipResponse =
 export class CanCreateRelationshipUseCase extends UseCase<CanCreateRelationshipRequest, CanCreateRelationshipResponse> {
     public constructor(
         @Inject private readonly relationshipController: RelationshipsController,
-        @Inject private readonly relationshipTemplateController: RelationshipTemplateController
+        @Inject private readonly relationshipTemplateController: RelationshipTemplateController,
+        @Inject validator: Validator
     ) {
-        super();
+        super(validator);
     }
 
     protected async executeInternal(request: CanCreateRelationshipRequest): Promise<Result<CanCreateRelationshipResponse>> {

--- a/packages/runtime/src/useCases/transport/relationships/CanCreateRelationship.ts
+++ b/packages/runtime/src/useCases/transport/relationships/CanCreateRelationship.ts
@@ -5,7 +5,6 @@ import { CoreId } from "@nmshd/core-types";
 import { RelationshipsController, RelationshipTemplate, RelationshipTemplateController } from "@nmshd/transport";
 import { Inject } from "@nmshd/typescript-ioc";
 import { RelationshipTemplateIdString, RuntimeErrors, SchemaRepository, SchemaValidator, UseCase } from "../../common";
-import {} from "./CreateRelationship";
 
 export interface CanCreateRelationshipRequest {
     templateId: RelationshipTemplateIdString;

--- a/packages/runtime/src/useCases/transport/relationships/index.ts
+++ b/packages/runtime/src/useCases/transport/relationships/index.ts
@@ -1,5 +1,6 @@
 export * from "./AcceptRelationship";
 export * from "./AcceptRelationshipReactivation";
+export * from "./CanCreateRelationship";
 export * from "./CreateRelationship";
 export * from "./DecomposeRelationship";
 export * from "./GetAttributesForRelationship";

--- a/packages/runtime/test/transport/relationships.test.ts
+++ b/packages/runtime/test/transport/relationships.test.ts
@@ -136,8 +136,7 @@ describe("Can Create / Create Relationship", () => {
 
         const canCreateRelationshipResponse = (
             await services2.transport.relationships.canCreateRelationship({
-                templateId: templateId,
-                creationContent: emptyRelationshipCreationContent
+                templateId: templateId
             })
         ).value;
 
@@ -167,8 +166,7 @@ describe("Can Create / Create Relationship", () => {
 
         const canCreateRelationshipResponse = (
             await services2.transport.relationships.canCreateRelationship({
-                templateId: templateId,
-                creationContent: emptyRelationshipCreationContent
+                templateId: templateId
             })
         ).value;
 
@@ -219,8 +217,7 @@ describe("Can Create / Create Relationship", () => {
 
             const canCreateRelationshipResponse = (
                 await services2.transport.relationships.canCreateRelationship({
-                    templateId: templateId,
-                    creationContent: emptyRelationshipCreationContent
+                    templateId: templateId
                 })
             ).value;
 
@@ -977,8 +974,7 @@ describe("RelationshipDecomposition", () => {
 
         const canCreateRelationshipResponse = (
             await services1.transport.relationships.canCreateRelationship({
-                templateId: templateId,
-                creationContent: emptyRelationshipCreationContent
+                templateId: templateId
             })
         ).value;
 


### PR DESCRIPTION
A `templateId` and a `creationContent` are required to create a Relationship, but to check whether a Relationship can in principle be established to the creator of the RelationshipTemplate, it is sufficient to specify the `templateId`. For this reason, the `creationContent` parameter of the CanCreateRelationshipUseCase is now made optional. The `creationContent` parameter can still be added if additional validation of the `creationContent` is wanted.

# Readiness checklist

-   [x] I added/updated tests.
-   [x] I ensured that the PR title is good enough for the changelog.
-   [x] I labeled the PR.
