### PR TITLE
Allow passing no title and description when uploading a file

### DIFF
--- a/packages/runtime/src/useCases/common/Schemas.ts
+++ b/packages/runtime/src/useCases/common/Schemas.ts
@@ -21641,8 +21641,7 @@ export const UploadOwnFileRequest: any = {
             "required": [
                 "content",
                 "filename",
-                "mimetype",
-                "title"
+                "mimetype"
             ],
             "additionalProperties": false
         },
@@ -21683,8 +21682,7 @@ export const UploadOwnFileValidatableRequest: any = {
             "required": [
                 "content",
                 "filename",
-                "mimetype",
-                "title"
+                "mimetype"
             ],
             "additionalProperties": false
         },

--- a/packages/runtime/src/useCases/transport/files/UploadOwnFile.ts
+++ b/packages/runtime/src/useCases/transport/files/UploadOwnFile.ts
@@ -13,7 +13,7 @@ export interface UploadOwnFileRequest {
     filename: string;
     mimetype: string;
     expiresAt?: ISO8601DateTimeString;
-    title: string;
+    title?: string;
     description?: string;
 }
 
@@ -77,16 +77,13 @@ export class UploadOwnFileUseCase extends UseCase<UploadOwnFileRequest, FileDTO>
     }
 
     protected async executeInternal(request: UploadOwnFileRequest): Promise<Result<FileDTO>> {
-        const maxDate = "9999-12-31T00:00:00.000Z";
-        const expiresAt = request.expiresAt ?? maxDate;
-
         const file = await this.fileController.sendFile({
             buffer: CoreBuffer.from(request.content),
             title: request.title,
-            description: request.description ?? "",
+            description: request.description,
             filename: request.filename,
             mimetype: request.mimetype,
-            expiresAt: CoreDate.from(expiresAt)
+            expiresAt: CoreDate.from(request.expiresAt ?? "9999-12-31T00:00:00.000Z")
         });
 
         await this.accountController.syncDatawallet();

--- a/packages/transport/src/modules/files/local/SendFileParameters.ts
+++ b/packages/transport/src/modules/files/local/SendFileParameters.ts
@@ -3,8 +3,8 @@ import { CoreDate, ICoreDate } from "@nmshd/core-types";
 import { CoreBuffer, ICoreBuffer } from "@nmshd/crypto";
 
 export interface ISendFileParameters extends ISerializable {
-    title: string;
-    description: string;
+    title?: string;
+    description?: string;
     filename: string;
     mimetype: string;
     expiresAt: ICoreDate;
@@ -14,18 +14,22 @@ export interface ISendFileParameters extends ISerializable {
 
 @type("SendFileParameters")
 export class SendFileParameters extends Serializable implements ISendFileParameters {
-    @validate()
+    @validate({ nullable: true })
     @serialize()
-    public title: string;
-    @validate()
+    public title?: string;
+
+    @validate({ nullable: true })
     @serialize()
-    public description: string;
+    public description?: string;
+
     @validate()
     @serialize()
     public filename: string;
+
     @validate()
     @serialize()
     public mimetype: string;
+
     @validate()
     @serialize()
     public expiresAt: CoreDate;


### PR DESCRIPTION
# Readiness checklist

-   [ ] I added/updated tests.
-   [x] I ensured that the PR title is good enough for the changelog.
-   [x] I labeled the PR.
-   [x] I self-reviewed the PR.

# Description

Seems like this was possible under the hood all the time and just propagated wrong.
