### PR TITLE
Bring `getAccountsInDeletion` and `getAccountsNotInDeletion` to `AccountServices`

### DIFF
--- a/packages/app-runtime/src/multiAccount/AccountServices.ts
+++ b/packages/app-runtime/src/multiAccount/AccountServices.ts
@@ -23,6 +23,16 @@ export class AccountServices {
         return localAccounts.map((account) => LocalAccountMapper.toLocalAccountDTO(account));
     }
 
+    public async getAccountsInDeletion(): Promise<LocalAccountDTO[]> {
+        const localAccounts = await this.multiAccountController.getAccountsInDeletion();
+        return localAccounts.map((account) => LocalAccountMapper.toLocalAccountDTO(account));
+    }
+
+    public async getAccountsNotInDeletion(): Promise<LocalAccountDTO[]> {
+        const localAccounts = await this.multiAccountController.getAccountsNotInDeletion();
+        return localAccounts.map((account) => LocalAccountMapper.toLocalAccountDTO(account));
+    }
+
     public async getAccount(id: string): Promise<LocalAccountDTO> {
         const localAccount = await this.multiAccountController.getAccount(CoreId.from(id));
         return LocalAccountMapper.toLocalAccountDTO(localAccount);

--- a/packages/app-runtime/src/multiAccount/MultiAccountController.ts
+++ b/packages/app-runtime/src/multiAccount/MultiAccountController.ts
@@ -78,20 +78,20 @@ export class MultiAccountController {
     }
 
     public async getAccounts(): Promise<LocalAccount[]> {
-        const dbAccounts = await this._localAccounts.list();
-        return dbAccounts.map((account) => LocalAccount.from(account));
+        return await this._findAccounts();
     }
 
     public async getAccountsInDeletion(): Promise<LocalAccount[]> {
-        const allAccounts = await this.getAccounts();
-        const accountsInDeletion = allAccounts.filter((item) => item.deletionDate !== undefined);
-        return accountsInDeletion;
+        return await this._findAccounts({ deletionDate: { $exists: true } });
     }
 
     public async getAccountsNotInDeletion(): Promise<LocalAccount[]> {
-        const allAccounts = await this.getAccounts();
-        const accountsNotInDeletion = allAccounts.filter((item) => item.deletionDate === undefined);
-        return accountsNotInDeletion;
+        return await this._findAccounts({ deletionDate: { $exists: false } });
+    }
+
+    private async _findAccounts(query?: any) {
+        const accounts = await this._localAccounts.find(query);
+        return accounts.map((account) => LocalAccount.from(account));
     }
 
     public async selectAccount(id: CoreId): Promise<[LocalAccount, AccountController]> {

--- a/packages/app-runtime/test/multiAccount/MultiAccountController.test.ts
+++ b/packages/app-runtime/test/multiAccount/MultiAccountController.test.ts
@@ -41,6 +41,16 @@ describe("MultiAccountController", function () {
 
     afterAll(async () => await runtime.stop());
 
+    test("should get all accounts", async function () {
+        const accounts = await runtime.multiAccountController.getAccounts();
+        expect(accounts).toHaveLength(3);
+
+        const addresses = accounts.map((account) => account.address!.toString());
+        expect(addresses).toContain(account1.address);
+        expect(addresses).toContain(account2.address);
+        expect(addresses).toContain(account3.address);
+    });
+
     test("should get all accounts in deletion", async function () {
         await session1.transportServices.identityDeletionProcesses.initiateIdentityDeletionProcess();
         await session2.transportServices.identityDeletionProcesses.initiateIdentityDeletionProcess();


### PR DESCRIPTION
# Readiness checklist

-   [x] I added/updated tests.
-   [x] I ensured that the PR title is good enough for the changelog.
-   [x] I labeled the PR.
-   [x] I self-reviewed the PR.

# Description

This adds some methods that got added to the MultiAccountController but not to the AccountServices.
