### PR TITLE
Simplify the PushNotificationModuleTest

### DIFF
--- a/packages/app-runtime/test/lib/TestUtil.ts
+++ b/packages/app-runtime/test/lib/TestUtil.ts
@@ -24,7 +24,7 @@ export class TestUtil {
     public static async createRuntime(configOverride?: any, uiBridge: IUIBridge = new FakeUIBridge(), eventBus?: EventBus): Promise<AppRuntime> {
         const config = this.createAppConfig(configOverride);
 
-        const nativeBootstrapper = new FakeNativeBootstrapper();
+        const nativeBootstrapper = new FakeNativeBootstrapper(eventBus);
         await nativeBootstrapper.init();
         const runtime = await AppRuntime.create(nativeBootstrapper, config, eventBus);
         runtime.registerUIBridge(uiBridge);

--- a/packages/app-runtime/test/lib/natives/FakeNativeBootstrapper.ts
+++ b/packages/app-runtime/test/lib/natives/FakeNativeBootstrapper.ts
@@ -1,4 +1,4 @@
-import { EventEmitter2EventBus, Result } from "@js-soft/ts-utils";
+import { EventBus, EventEmitter2EventBus, Result } from "@js-soft/ts-utils";
 import { WebLoggerFactory } from "@js-soft/web-logger";
 import { INativeBootstrapper, INativeEnvironment } from "../../../src";
 import { FakeNativeConfigAccess } from "./FakeNativeConfigAccess";
@@ -7,6 +7,8 @@ import { FakeNativeDeviceInfoAccess } from "./FakeNativeDeviceInfoAccess";
 import { FakeNativeNotificationAccess } from "./FakeNativeNotificationAccess";
 
 export class FakeNativeBootstrapper implements INativeBootstrapper {
+    public constructor(private readonly eventBus?: EventBus) {}
+
     private _nativeEnvironment: INativeEnvironment;
     public get nativeEnvironment(): INativeEnvironment {
         return this._nativeEnvironment;
@@ -24,9 +26,11 @@ export class FakeNativeBootstrapper implements INativeBootstrapper {
             configAccess: new FakeNativeConfigAccess(),
             databaseFactory: new FakeNativeDatabaseFactory(),
             deviceInfoAccess: new FakeNativeDeviceInfoAccess(),
-            eventBus: new EventEmitter2EventBus(() => {
-                // noop
-            }),
+            eventBus:
+                this.eventBus ??
+                new EventEmitter2EventBus(() => {
+                    // noop
+                }),
             loggerFactory,
             notificationAccess: new FakeNativeNotificationAccess(nativeLogger)
         };


### PR DESCRIPTION
# Readiness checklist

-   [x] I added/updated tests.
-   [x] I ensured that the PR title is good enough for the changelog.
-   [x] I labeled the PR.
-   [x] I self-reviewed the PR.

# Description

When using one EventBus for the whole test we win the flexibility to just wait for the EventBus to being finished with processing and then we can do checks.