### PR TITLE
Cannot create Relationship to deleted creator of RelationshipTemplate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7652,9 +7652,9 @@
             "optional": true
         },
         "node_modules/nanoid": {
-            "version": "3.3.7",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-            "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+            "version": "3.3.8",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+            "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
             "dev": true,
             "funding": [
                 {
@@ -7662,7 +7662,6 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "license": "MIT",
             "bin": {
                 "nanoid": "bin/nanoid.cjs"
             },

--- a/packages/transport/test/testHelpers/TestUtil.ts
+++ b/packages/transport/test/testHelpers/TestUtil.ts
@@ -290,6 +290,21 @@ export class TestUtil {
         return accountController;
     }
 
+    public static async exchangeTemplate(from: AccountController, to: AccountController): Promise<RelationshipTemplate> {
+        const templateFrom = await from.relationshipTemplates.sendRelationshipTemplate({
+            content: {
+                mycontent: "template"
+            },
+            expiresAt: CoreDate.utc().add({ minutes: 5 }),
+            maxNumberOfAllocations: 1
+        });
+
+        const templateReference = templateFrom.toRelationshipTemplateReference().truncate();
+        const templateTo = await to.relationshipTemplates.loadPeerRelationshipTemplateByTruncated(templateReference);
+
+        return templateTo;
+    }
+
     public static async addRejectedRelationship(from: AccountController, to: AccountController): Promise<Relationship> {
         const templateFrom = await from.relationshipTemplates.sendRelationshipTemplate({
             content: {


### PR DESCRIPTION
# Readiness checklist

- [x] I added/updated tests.
- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

# Description

It is now possible to test in the Transport library that a Relationship cannot be created after the RelationshipTemplate has been loaded if the creator of the RelationshipTemplate has deleted its Identity in the meantime.