### PR TITLE
Expose setting the length of the grace period when initiating an IdentityDeletionProcess

### DIFF
--- a/packages/app-runtime/test/runtime/Startup.test.ts
+++ b/packages/app-runtime/test/runtime/Startup.test.ts
@@ -87,14 +87,14 @@ describe("Start Accounts", function () {
     });
 
     test("should delete Account running startAccounts for an Identity with expired grace period", async function () {
-        await session.transportServices.identityDeletionProcesses["initiateIdentityDeletionProcessUseCase"]["identityDeletionProcessController"].initiateIdentityDeletionProcess(0);
+        await session.transportServices.identityDeletionProcesses.initiateIdentityDeletionProcess({ lengthOfGracePeriodInDays: 0 });
 
         await runtime["startAccounts"]();
         await expect(runtime.selectAccount(session.account.id)).rejects.toThrow("error.transport.recordNotFound");
     });
 
     test("should delete Account running startAccounts for a deleted Identity", async function () {
-        await session.transportServices.identityDeletionProcesses["initiateIdentityDeletionProcessUseCase"]["identityDeletionProcessController"].initiateIdentityDeletionProcess(0);
+        await session.transportServices.identityDeletionProcesses.initiateIdentityDeletionProcess({ lengthOfGracePeriodInDays: 0 });
         await TestUtil.runDeletionJob();
 
         await runtime["startAccounts"]();

--- a/packages/runtime/src/extensibility/facades/transport/IdentityDeletionProcessesFacade.ts
+++ b/packages/runtime/src/extensibility/facades/transport/IdentityDeletionProcessesFacade.ts
@@ -8,6 +8,7 @@ import {
     GetIdentityDeletionProcessesUseCase,
     GetIdentityDeletionProcessRequest,
     GetIdentityDeletionProcessUseCase,
+    InitiateIdentityDeletionProcessRequest,
     InitiateIdentityDeletionProcessUseCase,
     RejectIdentityDeletionProcessUseCase
 } from "../../../useCases";
@@ -31,8 +32,8 @@ export class IdentityDeletionProcessesFacade {
         return await this.rejectIdentityDeletionProcessUseCase.execute();
     }
 
-    public async initiateIdentityDeletionProcess(): Promise<Result<IdentityDeletionProcessDTO>> {
-        return await this.initiateIdentityDeletionProcessUseCase.execute();
+    public async initiateIdentityDeletionProcess(request: InitiateIdentityDeletionProcessRequest = {}): Promise<Result<IdentityDeletionProcessDTO>> {
+        return await this.initiateIdentityDeletionProcessUseCase.execute(request);
     }
 
     public async cancelIdentityDeletionProcess(): Promise<Result<IdentityDeletionProcessDTO>> {

--- a/packages/runtime/src/useCases/common/Schemas.ts
+++ b/packages/runtime/src/useCases/common/Schemas.ts
@@ -20638,6 +20638,22 @@ export const GetIdentityDeletionProcessRequest: any = {
     }
 }
 
+export const InitiateIdentityDeletionProcessRequest: any = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$ref": "#/definitions/InitiateIdentityDeletionProcessRequest",
+    "definitions": {
+        "InitiateIdentityDeletionProcessRequest": {
+            "type": "object",
+            "properties": {
+                "lengthOfGracePeriodInDays": {
+                    "type": "number"
+                }
+            },
+            "additionalProperties": false
+        }
+    }
+}
+
 export const DownloadAttachmentRequest: any = {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$ref": "#/definitions/DownloadAttachmentRequest",

--- a/packages/runtime/src/useCases/transport/identityDeletionProcesses/InitiateIdentityDeletionProcess.ts
+++ b/packages/runtime/src/useCases/transport/identityDeletionProcesses/InitiateIdentityDeletionProcess.ts
@@ -2,25 +2,36 @@ import { Result } from "@js-soft/ts-utils";
 import { AccountController, IdentityDeletionProcessController, IdentityDeletionProcessStatus } from "@nmshd/transport";
 import { Inject } from "@nmshd/typescript-ioc";
 import { IdentityDeletionProcessDTO } from "../../../types/transport/IdentityDeletionProcessDTO";
-import { RuntimeErrors, UseCase } from "../../common";
+import { RuntimeErrors, SchemaRepository, SchemaValidator, UseCase } from "../../common";
 import { IdentityDeletionProcessMapper } from "./IdentityDeletionProcessMapper";
 
-export class InitiateIdentityDeletionProcessUseCase extends UseCase<void, IdentityDeletionProcessDTO> {
+export interface InitiateIdentityDeletionProcessRequest {
+    lengthOfGracePeriodInDays?: number;
+}
+
+class Validator extends SchemaValidator<InitiateIdentityDeletionProcessRequest> {
+    public constructor(@Inject schemaRepository: SchemaRepository) {
+        super(schemaRepository.getSchema("InitiateIdentityDeletionProcessRequest"));
+    }
+}
+
+export class InitiateIdentityDeletionProcessUseCase extends UseCase<InitiateIdentityDeletionProcessRequest, IdentityDeletionProcessDTO> {
     public constructor(
         @Inject private readonly identityDeletionProcessController: IdentityDeletionProcessController,
-        @Inject private readonly accountController: AccountController
+        @Inject private readonly accountController: AccountController,
+        @Inject validator: Validator
     ) {
-        super();
+        super(validator);
     }
 
-    protected async executeInternal(): Promise<Result<IdentityDeletionProcessDTO>> {
+    protected async executeInternal(request: InitiateIdentityDeletionProcessRequest): Promise<Result<IdentityDeletionProcessDTO>> {
         const identityDeletionProcess = await this.identityDeletionProcessController.getIdentityDeletionProcessByStatus(
             IdentityDeletionProcessStatus.Approved,
             IdentityDeletionProcessStatus.WaitingForApproval
         );
         if (identityDeletionProcess) return Result.fail(RuntimeErrors.identityDeletionProcess.activeIdentityDeletionProcessAlreadyExists());
 
-        const initiatedIdentityDeletionProcess = await this.identityDeletionProcessController.initiateIdentityDeletionProcess();
+        const initiatedIdentityDeletionProcess = await this.identityDeletionProcessController.initiateIdentityDeletionProcess(request.lengthOfGracePeriodInDays);
         await this.accountController.syncDatawallet();
         return Result.ok(IdentityDeletionProcessMapper.toIdentityDeletionProcessDTO(initiatedIdentityDeletionProcess));
     }

--- a/packages/runtime/test/transport/account.test.ts
+++ b/packages/runtime/test/transport/account.test.ts
@@ -228,12 +228,11 @@ describe("CheckIfIdentityIsDeleted", () => {
     });
 
     test("check deletion of Identity that has IdentityDeletionProcess with expired grace period", async () => {
-        const identityDeletionProcess =
-            await sTransportServices.identityDeletionProcesses["initiateIdentityDeletionProcessUseCase"]["identityDeletionProcessController"].initiateIdentityDeletionProcess(0);
+        const identityDeletionProcess = await sTransportServices.identityDeletionProcesses.initiateIdentityDeletionProcess({ lengthOfGracePeriodInDays: 0 });
 
         const result = await sTransportServices.account.checkIfIdentityIsDeleted();
         expect(result.isSuccess).toBe(true);
         expect(result.value.isDeleted).toBe(true);
-        expect(result.value.deletionDate).toBe(identityDeletionProcess.cache!.gracePeriodEndsAt!.toString());
+        expect(result.value.deletionDate).toBe(identityDeletionProcess.value.gracePeriodEndsAt!.toString());
     });
 });


### PR DESCRIPTION
# Readiness checklist

- [ ] I added/updated tests.
- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [ ] I self-reviewed the PR.

# Description

I discussed this with @tnotheis and it's the best possibility for testing this feature end to end without having to adjust the backbone for every test. We see minimal to no attack vector to this as we simple cannot use this and an attacker could use this anyways by just calling the backbone manually.

As a cherry on top this makes our tests way more readable!
