### PR TITLE
RequestConfig is skipped if false is configured as value

### DIFF
--- a/packages/runtime/src/modules/DeciderModule.ts
+++ b/packages/runtime/src/modules/DeciderModule.ts
@@ -291,13 +291,13 @@ function checkCompatibility(requestConfigElement: RequestConfig, requestOrReques
     let compatible = true;
     for (const property in requestConfigElement) {
         const unformattedRequestConfigProperty = requestConfigElement[property as keyof RequestConfig];
-        if (!unformattedRequestConfigProperty) {
+        if (typeof unformattedRequestConfigProperty === "undefined") {
             continue;
         }
         const requestConfigProperty = makeObjectsToStrings(unformattedRequestConfigProperty);
 
         const unformattedRequestProperty = getNestedProperty(requestOrRequestItem, property);
-        if (!unformattedRequestProperty) {
+        if (typeof unformattedRequestProperty === "undefined") {
             compatible = false;
             break;
         }

--- a/packages/runtime/src/modules/decide/RequestConfig.ts
+++ b/packages/runtime/src/modules/decide/RequestConfig.ts
@@ -56,7 +56,6 @@ export interface FreeTextRequestItemConfig extends RequestItemConfig {
 export interface ProposeAttributeRequestItemConfig extends RequestItemConfig {
     "content.item.@type": "ProposeAttributeRequestItem";
     "content.item.attribute.@type"?: "IdentityAttribute" | "RelationshipAttribute";
-    "content.item.attribute.owner"?: string | string[];
     "content.item.attribute.validFrom"?: string | string[];
     "content.item.attribute.validTo"?: string | string[];
     "content.item.attribute.tags"?: string[];
@@ -73,7 +72,6 @@ export interface ProposeAttributeRequestItemConfig extends RequestItemConfig {
     "content.item.query.valueType"?: string | string[];
     "content.item.query.tags"?: string[];
     "content.item.query.key"?: string | string[];
-    "content.item.query.owner"?: string | string[];
     "content.item.query.queryString"?: string | string[];
     "content.item.query.attributeCreationHints.title"?: string | string[];
     "content.item.query.attributeCreationHints.description"?: string | string[];

--- a/packages/runtime/test/modules/DeciderModule.test.ts
+++ b/packages/runtime/test/modules/DeciderModule.test.ts
@@ -466,7 +466,7 @@ describe("DeciderModule", () => {
             );
         });
 
-        test("cannot decide a Request givena GeneralRequestConfig  with an expiration date too low", async () => {
+        test("cannot decide a Request given a GeneralRequestConfig  with an expiration date too low", async () => {
             const requestExpirationDate = CoreDate.utc().add({ days: 1 }).toString();
             const deciderConfig: DeciderModuleConfigurationOverwrite = {
                 automationConfig: [

--- a/packages/runtime/test/modules/DeciderModule.test.ts
+++ b/packages/runtime/test/modules/DeciderModule.test.ts
@@ -850,44 +850,6 @@ describe("DeciderModule", () => {
                 automationConfig: [
                     {
                         requestConfig: {
-                            "content.item.mustBeAccepted": false
-                        },
-                        responseConfig: {
-                            accept: false
-                        }
-                    }
-                ]
-            };
-            const recipient = (await runtimeServiceProvider.launch(1, { enableDeciderModule: true, configureDeciderModule: deciderConfig }))[0];
-            await establishRelationship(sender.transport, recipient.transport);
-
-            const message = await exchangeMessage(sender.transport, recipient.transport);
-            const receivedRequestResult = await recipient.consumption.incomingRequests.received({
-                receivedRequest: {
-                    "@type": "Request",
-                    items: [
-                        {
-                            "@type": "AuthenticationRequestItem",
-                            mustBeAccepted: true,
-                            title: "Title of RequestItem"
-                        }
-                    ]
-                },
-                requestSourceId: message.id
-            });
-            await recipient.consumption.incomingRequests.checkPrerequisites({ requestId: receivedRequestResult.value.id });
-
-            await expect(recipient.eventBus).toHavePublished(
-                MessageProcessedEvent,
-                (e) => e.data.result === MessageProcessedResult.ManualRequestDecisionRequired && e.data.message.id === message.id
-            );
-        });
-
-        test("cannot decide a RequestItem given a RequestItemConfig that doesn't fit the RequestItem regarding a boolean property", async () => {
-            const deciderConfig: DeciderModuleConfigurationOverwrite = {
-                automationConfig: [
-                    {
-                        requestConfig: {
                             "content.item.@type": "AuthenticationRequestItem",
                             "content.item.title": "Another title of RequestItem"
                         },
@@ -908,6 +870,44 @@ describe("DeciderModule", () => {
                         {
                             "@type": "AuthenticationRequestItem",
                             mustBeAccepted: false,
+                            title: "Title of RequestItem"
+                        }
+                    ]
+                },
+                requestSourceId: message.id
+            });
+            await recipient.consumption.incomingRequests.checkPrerequisites({ requestId: receivedRequestResult.value.id });
+
+            await expect(recipient.eventBus).toHavePublished(
+                MessageProcessedEvent,
+                (e) => e.data.result === MessageProcessedResult.ManualRequestDecisionRequired && e.data.message.id === message.id
+            );
+        });
+
+        test("cannot decide a RequestItem given a RequestItemConfig that doesn't fit the RequestItem regarding a boolean property", async () => {
+            const deciderConfig: DeciderModuleConfigurationOverwrite = {
+                automationConfig: [
+                    {
+                        requestConfig: {
+                            "content.item.mustBeAccepted": false
+                        },
+                        responseConfig: {
+                            accept: false
+                        }
+                    }
+                ]
+            };
+            const recipient = (await runtimeServiceProvider.launch(1, { enableDeciderModule: true, configureDeciderModule: deciderConfig }))[0];
+            await establishRelationship(sender.transport, recipient.transport);
+
+            const message = await exchangeMessage(sender.transport, recipient.transport);
+            const receivedRequestResult = await recipient.consumption.incomingRequests.received({
+                receivedRequest: {
+                    "@type": "Request",
+                    items: [
+                        {
+                            "@type": "AuthenticationRequestItem",
+                            mustBeAccepted: true,
                             title: "Title of RequestItem"
                         }
                     ]

--- a/packages/runtime/test/modules/DeciderModule.test.ts
+++ b/packages/runtime/test/modules/DeciderModule.test.ts
@@ -300,7 +300,6 @@ describe("DeciderModule", () => {
                 ]
             };
             const recipient = (await runtimeServiceProvider.launch(1, { enableDeciderModule: true, configureDeciderModule: deciderConfig }))[0];
-            await establishRelationship(sender.transport, recipient.transport);
 
             const request = Request.from({
                 expiresAt: requestExpirationDate.toString(),
@@ -437,7 +436,7 @@ describe("DeciderModule", () => {
             );
         });
 
-        test("cannot decide a Request given with an expiration date too high", async () => {
+        test("cannot decide a Request given a GeneralRequestConfig with an expiration date too high", async () => {
             const requestExpirationDate = CoreDate.utc().add({ days: 1 }).toString();
             const deciderConfig: DeciderModuleConfigurationOverwrite = {
                 automationConfig: [
@@ -467,7 +466,7 @@ describe("DeciderModule", () => {
             );
         });
 
-        test("cannot decide a Request given with an expiration date too low", async () => {
+        test("cannot decide a Request givena GeneralRequestConfig  with an expiration date too low", async () => {
             const requestExpirationDate = CoreDate.utc().add({ days: 1 }).toString();
             const deciderConfig: DeciderModuleConfigurationOverwrite = {
                 automationConfig: [
@@ -847,6 +846,44 @@ describe("DeciderModule", () => {
         });
 
         test("cannot decide a RequestItem given a RequestItemConfig that doesn't fit the RequestItem", async () => {
+            const deciderConfig: DeciderModuleConfigurationOverwrite = {
+                automationConfig: [
+                    {
+                        requestConfig: {
+                            "content.item.mustBeAccepted": false
+                        },
+                        responseConfig: {
+                            accept: false
+                        }
+                    }
+                ]
+            };
+            const recipient = (await runtimeServiceProvider.launch(1, { enableDeciderModule: true, configureDeciderModule: deciderConfig }))[0];
+            await establishRelationship(sender.transport, recipient.transport);
+
+            const message = await exchangeMessage(sender.transport, recipient.transport);
+            const receivedRequestResult = await recipient.consumption.incomingRequests.received({
+                receivedRequest: {
+                    "@type": "Request",
+                    items: [
+                        {
+                            "@type": "AuthenticationRequestItem",
+                            mustBeAccepted: true,
+                            title: "Title of RequestItem"
+                        }
+                    ]
+                },
+                requestSourceId: message.id
+            });
+            await recipient.consumption.incomingRequests.checkPrerequisites({ requestId: receivedRequestResult.value.id });
+
+            await expect(recipient.eventBus).toHavePublished(
+                MessageProcessedEvent,
+                (e) => e.data.result === MessageProcessedResult.ManualRequestDecisionRequired && e.data.message.id === message.id
+            );
+        });
+
+        test("cannot decide a RequestItem given a RequestItemConfig that doesn't fit the RequestItem regarding a boolean property", async () => {
             const deciderConfig: DeciderModuleConfigurationOverwrite = {
                 automationConfig: [
                     {

--- a/packages/runtime/test/modules/DeciderModule.test.ts
+++ b/packages/runtime/test/modules/DeciderModule.test.ts
@@ -1466,7 +1466,6 @@ describe("DeciderModule", () => {
                         requestConfig: {
                             "content.item.@type": "ProposeAttributeRequestItem",
                             "content.item.attribute.@type": "RelationshipAttribute",
-                            "content.item.attribute.owner": "",
                             "content.item.attribute.validFrom": attributeValidFrom,
                             "content.item.attribute.validTo": attributeValidTo,
                             "content.item.attribute.key": "A key",

--- a/packages/runtime/test/modules/DeciderModule.test.ts
+++ b/packages/runtime/test/modules/DeciderModule.test.ts
@@ -1479,7 +1479,6 @@ describe("DeciderModule", () => {
                             "content.item.query.validFrom": attributeValidFrom,
                             "content.item.query.validTo": attributeValidTo,
                             "content.item.query.key": "A key",
-                            "content.item.query.owner": "",
                             "content.item.query.attributeCreationHints.title": "Title of Attribute",
                             "content.item.query.attributeCreationHints.description": "Description of Attribute",
                             "content.item.query.attributeCreationHints.valueType": "ProprietaryString",


### PR DESCRIPTION
# Readiness checklist

- [x] I added/updated tests.
- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

# Description

Also, `owner` is removed from `ProposeAttributeRequestItemConfig` since it can only be the recipient anyway.

There remain problems with the `owner` of a CreateAttributeRequestItem and ReadAttributeRequestItem, because an empty strings needs to be converted to the address of the recipient. However, I'll tackle these issues in a separate PR.
