### PR TITLE
Move check for RepositoryAttribute duplicates to AttributesController

### DIFF
--- a/packages/consumption/src/modules/attributes/AttributesController.ts
+++ b/packages/consumption/src/modules/attributes/AttributesController.ts
@@ -25,7 +25,7 @@ import { ConsumptionControllerName } from "../../consumption/ConsumptionControll
 import { ConsumptionCoreErrors } from "../../consumption/ConsumptionCoreErrors";
 import { ConsumptionError } from "../../consumption/ConsumptionError";
 import { ConsumptionIds } from "../../consumption/ConsumptionIds";
-import { ValidationResult } from "../common";
+import { flattenObject, ValidationResult } from "../common";
 import {
     AttributeCreatedEvent,
     AttributeDeletedEvent,
@@ -1295,7 +1295,7 @@ export class AttributesController extends ConsumptionBaseController {
     }
 
     public async getRepositoryAttributesWithSameValue(value: AttributeValues.Identity.Json): Promise<LocalAttribute[]> {
-        const queryForRepositoryAttributeDuplicates = this.flattenObject({
+        const queryForRepositoryAttributeDuplicates = flattenObject({
             content: {
                 "@type": "IdentityAttribute",
                 owner: this.identity.address.toString(),
@@ -1304,32 +1304,7 @@ export class AttributesController extends ConsumptionBaseController {
         });
         queryForRepositoryAttributeDuplicates["succeededBy"] = { $exists: false };
 
-        // const flattenedValue = this.flattenObject({ content: { value: value } });
-        // const queryForRepositoryAttributeDuplicates = {
-        //     "content.@type": "IdentityAttribute",
-        //     "content.owner": this.identity.address.toString(),
-        //     ...flattenedValue,
-        //     succeededBy: { $exists: false }
-        // };
-
         const result = await this.getLocalAttributes(queryForRepositoryAttributeDuplicates);
-        return result;
-    }
-
-    private flattenObject(object: any): Record<string, unknown> {
-        const result: Record<string, unknown> = {};
-
-        for (const key in object) {
-            const propertyValue = object[key];
-            if (typeof propertyValue === "object" && !Array.isArray(propertyValue)) {
-                const temp = this.flattenObject(propertyValue);
-                for (const j in temp) {
-                    result[`${key}.${j}`] = temp[j];
-                }
-            } else {
-                result[key] = propertyValue;
-            }
-        }
         return result;
     }
 

--- a/packages/consumption/src/modules/attributes/AttributesController.ts
+++ b/packages/consumption/src/modules/attributes/AttributesController.ts
@@ -1304,8 +1304,7 @@ export class AttributesController extends ConsumptionBaseController {
         });
         queryForRepositoryAttributeDuplicates["succeededBy"] = { $exists: false };
 
-        const result = await this.getLocalAttributes(queryForRepositoryAttributeDuplicates);
-        return result;
+        return await this.getLocalAttributes(queryForRepositoryAttributeDuplicates);
     }
 
     public async getRelationshipAttributesOfValueTypeToPeerWithGivenKeyAndOwner(key: string, owner: CoreAddress, valueType: string, peer: CoreAddress): Promise<LocalAttribute[]> {

--- a/packages/consumption/src/modules/attributes/AttributesController.ts
+++ b/packages/consumption/src/modules/attributes/AttributesController.ts
@@ -1294,6 +1294,17 @@ export class AttributesController extends ConsumptionBaseController {
         return ownSharedAttributeSuccessors;
     }
 
+    public async getRepositoryAttributesWithSameValue(value: AttributeValues.Identity.Json): Promise<LocalAttribute[]> {
+        const queryForRepositoryAttributeDuplicates = {
+            "content.@type": "IdentityAttribute",
+            "content.owner": this.identity.address.toString(),
+            "content.value": value,
+            succeededBy: { $exists: false }
+        };
+
+        return await this.getLocalAttributes(queryForRepositoryAttributeDuplicates);
+    }
+
     public async getRelationshipAttributesOfValueTypeToPeerWithGivenKeyAndOwner(key: string, owner: CoreAddress, valueType: string, peer: CoreAddress): Promise<LocalAttribute[]> {
         return await this.getLocalAttributes({
             "content.@type": "RelationshipAttribute",

--- a/packages/consumption/src/modules/attributes/AttributesController.ts
+++ b/packages/consumption/src/modules/attributes/AttributesController.ts
@@ -1295,13 +1295,22 @@ export class AttributesController extends ConsumptionBaseController {
     }
 
     public async getRepositoryAttributesWithSameValue(value: AttributeValues.Identity.Json): Promise<LocalAttribute[]> {
-        const flattenedValue = this.flattenObject(value);
-        const queryForRepositoryAttributeDuplicates = {
-            "content.@type": "IdentityAttribute",
-            "content.owner": this.identity.address.toString(),
-            ...flattenedValue,
-            succeededBy: { $exists: false }
-        };
+        const queryForRepositoryAttributeDuplicates = this.flattenObject({
+            content: {
+                "@type": "IdentityAttribute",
+                owner: this.identity.address.toString(),
+                value: value
+            }
+        });
+        queryForRepositoryAttributeDuplicates["succeededBy"] = { $exists: false };
+
+        // const flattenedValue = this.flattenObject({ content: { value: value } });
+        // const queryForRepositoryAttributeDuplicates = {
+        //     "content.@type": "IdentityAttribute",
+        //     "content.owner": this.identity.address.toString(),
+        //     ...flattenedValue,
+        //     succeededBy: { $exists: false }
+        // };
 
         const result = await this.getLocalAttributes(queryForRepositoryAttributeDuplicates);
         return result;

--- a/packages/consumption/src/modules/attributes/AttributesController.ts
+++ b/packages/consumption/src/modules/attributes/AttributesController.ts
@@ -1294,7 +1294,7 @@ export class AttributesController extends ConsumptionBaseController {
         return ownSharedAttributeSuccessors;
     }
 
-    public async getRepositoryAttributesWithSameValue(value: AttributeValues.Identity.Json): Promise<LocalAttribute[]> {
+    public async getRepositoryAttributeWithSameValue(value: AttributeValues.Identity.Json): Promise<LocalAttribute | undefined> {
         const queryForRepositoryAttributeDuplicates = flattenObject({
             content: {
                 "@type": "IdentityAttribute",
@@ -1304,7 +1304,10 @@ export class AttributesController extends ConsumptionBaseController {
         });
         queryForRepositoryAttributeDuplicates["succeededBy"] = { $exists: false };
 
-        return await this.getLocalAttributes(queryForRepositoryAttributeDuplicates);
+        const matchingRepositoryAttributes = await this.getLocalAttributes(queryForRepositoryAttributeDuplicates);
+
+        const repositoryAttributeDuplicate = matchingRepositoryAttributes.find((duplicate) => _.isEqual(duplicate.content.value.toJSON(), value));
+        return repositoryAttributeDuplicate;
     }
 
     public async getRelationshipAttributesOfValueTypeToPeerWithGivenKeyAndOwner(key: string, owner: CoreAddress, valueType: string, peer: CoreAddress): Promise<LocalAttribute[]> {

--- a/packages/consumption/src/modules/common/flattenObject.ts
+++ b/packages/consumption/src/modules/common/flattenObject.ts
@@ -1,0 +1,16 @@
+export function flattenObject(object: any): Record<string, unknown> {
+    const result: Record<string, unknown> = {};
+
+    for (const key in object) {
+        const propertyValue = object[key];
+        if (typeof propertyValue === "object" && !Array.isArray(propertyValue)) {
+            const temp = flattenObject(propertyValue);
+            for (const j in temp) {
+                result[`${key}.${j}`] = temp[j];
+            }
+        } else {
+            result[key] = propertyValue;
+        }
+    }
+    return result;
+}

--- a/packages/consumption/src/modules/common/index.ts
+++ b/packages/consumption/src/modules/common/index.ts
@@ -1,1 +1,2 @@
+export * from "./flattenObject";
 export * from "./ValidationResult";

--- a/packages/consumption/src/modules/requests/itemProcessors/createAttribute/CreateAttributeRequestItemProcessor.ts
+++ b/packages/consumption/src/modules/requests/itemProcessors/createAttribute/CreateAttributeRequestItemProcessor.ts
@@ -21,6 +21,9 @@ export class CreateAttributeRequestItemProcessor extends GenericRequestItemProce
         const senderIsAttributeOwner = requestItem.attribute.owner.equals(this.currentIdentityAddress);
         const ownerIsEmptyString = requestItem.attribute.owner.toString() === "";
 
+        // TODO: add check for shared duplicate -> return error
+        // TODO: check that not two Items of same Request will create same Attribute (see key uniqueness)
+
         if (requestItem.attribute instanceof IdentityAttribute) {
             if (recipientIsAttributeOwner || ownerIsEmptyString) {
                 return ValidationResult.success();
@@ -110,6 +113,7 @@ export class CreateAttributeRequestItemProcessor extends GenericRequestItemProce
         let sharedAttribute: LocalAttribute;
 
         if (requestItem.attribute instanceof IdentityAttribute) {
+            // TODO: check for existing RepositoryAttribute -> link to it
             const repositoryAttribute = await this.consumptionController.attributes.createRepositoryAttribute({
                 content: requestItem.attribute
             });

--- a/packages/consumption/src/modules/requests/itemProcessors/createAttribute/CreateAttributeRequestItemProcessor.ts
+++ b/packages/consumption/src/modules/requests/itemProcessors/createAttribute/CreateAttributeRequestItemProcessor.ts
@@ -21,9 +21,6 @@ export class CreateAttributeRequestItemProcessor extends GenericRequestItemProce
         const senderIsAttributeOwner = requestItem.attribute.owner.equals(this.currentIdentityAddress);
         const ownerIsEmptyString = requestItem.attribute.owner.toString() === "";
 
-        // TODO: add check for shared duplicate -> return error
-        // TODO: check that not two Items of same Request will create same Attribute (see key uniqueness)
-
         if (requestItem.attribute instanceof IdentityAttribute) {
             if (recipientIsAttributeOwner || ownerIsEmptyString) {
                 return ValidationResult.success();
@@ -113,7 +110,6 @@ export class CreateAttributeRequestItemProcessor extends GenericRequestItemProce
         let sharedAttribute: LocalAttribute;
 
         if (requestItem.attribute instanceof IdentityAttribute) {
-            // TODO: check for existing RepositoryAttribute -> link to it
             const repositoryAttribute = await this.consumptionController.attributes.createRepositoryAttribute({
                 content: requestItem.attribute
             });

--- a/packages/runtime/src/useCases/consumption/attributes/CreateRepositoryAttribute.ts
+++ b/packages/runtime/src/useCases/consumption/attributes/CreateRepositoryAttribute.ts
@@ -20,8 +20,6 @@ interface AbstractCreateRepositoryAttributeRequest<T> {
 
 export interface CreateRepositoryAttributeRequest extends AbstractCreateRepositoryAttributeRequest<AttributeValues.Identity.Json> {}
 
-export interface SchemaValidatableCreateRepositoryAttributeRequest extends AbstractCreateRepositoryAttributeRequest<unknown> {}
-
 class Validator implements IValidator<CreateRepositoryAttributeRequest> {
     public constructor(@Inject private readonly schemaRepository: SchemaRepository) {}
 

--- a/packages/runtime/src/useCases/consumption/attributes/CreateRepositoryAttribute.ts
+++ b/packages/runtime/src/useCases/consumption/attributes/CreateRepositoryAttribute.ts
@@ -62,7 +62,7 @@ class Validator implements IValidator<CreateRepositoryAttributeRequest> {
 
 export class CreateRepositoryAttributeUseCase extends UseCase<CreateRepositoryAttributeRequest, LocalAttributeDTO> {
     public constructor(
-        @Inject private readonly attributeController: AttributesController,
+        @Inject private readonly attributesController: AttributesController,
         @Inject private readonly accountController: AccountController,
         @Inject validator: Validator
     ) {
@@ -70,7 +70,7 @@ export class CreateRepositoryAttributeUseCase extends UseCase<CreateRepositoryAt
     }
 
     protected async executeInternal(request: CreateRepositoryAttributeRequest): Promise<Result<LocalAttributeDTO>> {
-        const duplicateRepositoryAttributes = await this.attributeController.getRepositoryAttributesWithSameValue(request.content.value);
+        const duplicateRepositoryAttributes = await this.attributesController.getRepositoryAttributesWithSameValue(request.content.value);
 
         const exactMatchExists = duplicateRepositoryAttributes.some((duplicate) => _.isEqual(duplicate.content.value.toJSON(), request.content.value));
         if (exactMatchExists) {
@@ -84,7 +84,7 @@ export class CreateRepositoryAttributeUseCase extends UseCase<CreateRepositoryAt
                 ...request.content
             }
         });
-        const createdLocalAttribute = await this.attributeController.createRepositoryAttribute(params);
+        const createdLocalAttribute = await this.attributesController.createRepositoryAttribute(params);
 
         await this.accountController.syncDatawallet();
 

--- a/packages/runtime/src/useCases/consumption/attributes/CreateRepositoryAttribute.ts
+++ b/packages/runtime/src/useCases/consumption/attributes/CreateRepositoryAttribute.ts
@@ -20,6 +20,8 @@ interface AbstractCreateRepositoryAttributeRequest<T> {
 
 export interface CreateRepositoryAttributeRequest extends AbstractCreateRepositoryAttributeRequest<AttributeValues.Identity.Json> {}
 
+export interface SchemaValidatableCreateRepositoryAttributeRequest extends AbstractCreateRepositoryAttributeRequest<unknown> {}
+
 class Validator implements IValidator<CreateRepositoryAttributeRequest> {
     public constructor(@Inject private readonly schemaRepository: SchemaRepository) {}
 

--- a/packages/runtime/src/useCases/consumption/attributes/CreateRepositoryAttribute.ts
+++ b/packages/runtime/src/useCases/consumption/attributes/CreateRepositoryAttribute.ts
@@ -3,7 +3,6 @@ import { AttributesController, CreateRepositoryAttributeParams } from "@nmshd/co
 import { AttributeValues } from "@nmshd/content";
 import { AccountController } from "@nmshd/transport";
 import { Inject } from "@nmshd/typescript-ioc";
-import _ from "lodash";
 import { LocalAttributeDTO } from "../../../types";
 import { ISO8601DateTimeString, RuntimeErrors, SchemaRepository, SchemaValidator, UseCase, ValidationFailure, ValidationResult } from "../../common";
 import { IValidator } from "../../common/validation/IValidator";
@@ -72,11 +71,9 @@ export class CreateRepositoryAttributeUseCase extends UseCase<CreateRepositoryAt
     }
 
     protected async executeInternal(request: CreateRepositoryAttributeRequest): Promise<Result<LocalAttributeDTO>> {
-        const duplicateRepositoryAttributes = await this.attributesController.getRepositoryAttributesWithSameValue(request.content.value);
-
-        const exactMatchExists = duplicateRepositoryAttributes.some((duplicate) => _.isEqual(duplicate.content.value.toJSON(), request.content.value));
-        if (exactMatchExists) {
-            return Result.fail(RuntimeErrors.attributes.cannotCreateDuplicateRepositoryAttribute(duplicateRepositoryAttributes[0].id));
+        const repositoryAttributeDuplicate = await this.attributesController.getRepositoryAttributeWithSameValue(request.content.value);
+        if (repositoryAttributeDuplicate) {
+            return Result.fail(RuntimeErrors.attributes.cannotCreateDuplicateRepositoryAttribute(repositoryAttributeDuplicate.id));
         }
 
         const params = CreateRepositoryAttributeParams.from({


### PR DESCRIPTION
# Readiness checklist

- [ ] I added/updated tests.
- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

# Description

I moved this to a lower level to be able to reuse it. This is advantageous for preventing the creation of duplicate RepositoryAttributes via a Request. Also, it allows to implement a CanCreateRepositoryAttribute use case more easily.