### PR TITLE
Make app-runtime modules configurable and simplfy the app-runtime startup

### DIFF
--- a/packages/app-runtime/src/AppConfig.ts
+++ b/packages/app-runtime/src/AppConfig.ts
@@ -13,13 +13,14 @@ export interface AppConfig extends RuntimeConfig {
 export interface AppConfigOverwrite {
     transportLibrary?: Omit<IConfigOverwrite, "supportedIdentityVersion">;
     accountsDbName?: string;
-    applicationId: string;
+    applicationId?: string;
     applePushEnvironment?: "Development" | "Production";
     allowMultipleAccountsWithSameAddress?: boolean;
     databaseFolder?: string;
+    modules?: Record<string, { enabled?: boolean; [x: string | number | symbol]: unknown }>;
 }
 
-export function createAppConfig(...configs: AppConfigOverwrite[]): AppConfig {
+export function createAppConfig(...configs: (AppConfigOverwrite | AppConfig | undefined)[]): AppConfig {
     const appConfig: Omit<AppConfig, "transportLibrary" | "applicationId"> & {
         transportLibrary: Omit<IConfigOverwrite, "supportedIdentityVersion" | "platformClientId" | "platformClientSecret" | "baseUrl">;
     } = {

--- a/packages/app-runtime/src/AppConfig.ts
+++ b/packages/app-runtime/src/AppConfig.ts
@@ -20,7 +20,7 @@ export interface AppConfigOverwrite {
     modules?: Record<string, { enabled?: boolean; [x: string | number | symbol]: unknown }>;
 }
 
-export function createAppConfig(...configs: (AppConfigOverwrite | AppConfig | undefined)[]): AppConfig {
+export function createAppConfig(...configs: (AppConfigOverwrite | AppConfig)[]): AppConfig {
     const appConfig: Omit<AppConfig, "transportLibrary" | "applicationId"> & {
         transportLibrary: Omit<IConfigOverwrite, "supportedIdentityVersion" | "platformClientId" | "platformClientSecret" | "baseUrl">;
     } = {

--- a/packages/app-runtime/src/AppRuntime.ts
+++ b/packages/app-runtime/src/AppRuntime.ts
@@ -203,7 +203,7 @@ export class AppRuntime extends Runtime<AppConfig> {
         this._accountServices = new AccountServices(this._multiAccountController);
     }
 
-    public static async create(nativeBootstrapper: INativeBootstrapper, appConfig?: AppConfigOverwrite | AppConfig, eventBus?: EventBus): Promise<AppRuntime> {
+    public static async create(nativeBootstrapper: INativeBootstrapper, appConfig: AppConfigOverwrite | AppConfig = {}, eventBus?: EventBus): Promise<AppRuntime> {
         // TODO: JSSNMSHDD-2524 (validate app config)
 
         if (!nativeBootstrapper.isInitialized) {
@@ -213,24 +213,7 @@ export class AppRuntime extends Runtime<AppConfig> {
             }
         }
 
-        const applePushEnvironmentResult = nativeBootstrapper.nativeEnvironment.configAccess.get("applePushEnvironment");
-        const applePushEnvironment = applePushEnvironmentResult.isError ? undefined : applePushEnvironmentResult.value;
-
-        const applicationId = nativeBootstrapper.nativeEnvironment.configAccess.get("applicationId").value;
-        const transportConfig = nativeBootstrapper.nativeEnvironment.configAccess.get("transport").value;
-        const databaseFolder = nativeBootstrapper.nativeEnvironment.configAccess.get("databaseFolder").value;
-        const modules = nativeBootstrapper.nativeEnvironment.configAccess.get("modules").value;
-
-        const mergedConfig = createAppConfig(
-            {
-                transportLibrary: transportConfig,
-                applicationId: applicationId,
-                applePushEnvironment: applePushEnvironment,
-                databaseFolder: databaseFolder,
-                modules: modules
-            },
-            appConfig
-        );
+        const mergedConfig = createAppConfig(appConfig);
 
         const runtime = new AppRuntime(nativeBootstrapper.nativeEnvironment, mergedConfig, eventBus);
         await runtime.init();

--- a/packages/app-runtime/src/AppRuntime.ts
+++ b/packages/app-runtime/src/AppRuntime.ts
@@ -203,7 +203,7 @@ export class AppRuntime extends Runtime<AppConfig> {
         this._accountServices = new AccountServices(this._multiAccountController);
     }
 
-    public static async create(nativeBootstrapper: INativeBootstrapper, appConfig?: AppConfigOverwrite, eventBus?: EventBus): Promise<AppRuntime> {
+    public static async create(nativeBootstrapper: INativeBootstrapper, appConfig?: AppConfigOverwrite | AppConfig, eventBus?: EventBus): Promise<AppRuntime> {
         // TODO: JSSNMSHDD-2524 (validate app config)
 
         if (!nativeBootstrapper.isInitialized) {
@@ -219,22 +219,18 @@ export class AppRuntime extends Runtime<AppConfig> {
         const applicationId = nativeBootstrapper.nativeEnvironment.configAccess.get("applicationId").value;
         const transportConfig = nativeBootstrapper.nativeEnvironment.configAccess.get("transport").value;
         const databaseFolder = nativeBootstrapper.nativeEnvironment.configAccess.get("databaseFolder").value;
+        const modules = nativeBootstrapper.nativeEnvironment.configAccess.get("modules").value;
 
-        const mergedConfig = appConfig
-            ? createAppConfig(
-                  {
-                      transportLibrary: transportConfig,
-                      applicationId: applicationId,
-                      applePushEnvironment: applePushEnvironment
-                  },
-                  appConfig
-              )
-            : createAppConfig({
-                  transportLibrary: transportConfig,
-                  applicationId: applicationId,
-                  applePushEnvironment: applePushEnvironment,
-                  databaseFolder: databaseFolder
-              });
+        const mergedConfig = createAppConfig(
+            {
+                transportLibrary: transportConfig,
+                applicationId: applicationId,
+                applePushEnvironment: applePushEnvironment,
+                databaseFolder: databaseFolder,
+                modules: modules
+            },
+            appConfig
+        );
 
         const runtime = new AppRuntime(nativeBootstrapper.nativeEnvironment, mergedConfig, eventBus);
         await runtime.init();

--- a/packages/app-runtime/src/natives/INativeConfigAccess.ts
+++ b/packages/app-runtime/src/natives/INativeConfigAccess.ts
@@ -5,6 +5,4 @@ export interface INativeConfigAccess {
     set(key: string, value: any): Result<void>;
     remove(key: string): Result<void>;
     save(): Promise<Result<void>>;
-    initDefaultConfig(path: string): Promise<Result<void>>;
-    initRuntimeConfig(path: string): Promise<Result<void>>;
 }

--- a/packages/app-runtime/test/lib/TestUtil.ts
+++ b/packages/app-runtime/test/lib/TestUtil.ts
@@ -20,12 +20,12 @@ import { defaultsDeep } from "lodash";
 import path from "path";
 import { GenericContainer, Wait } from "testcontainers";
 import { LogLevel } from "typescript-logging";
-import { AppConfig, AppRuntime, IUIBridge, LocalAccountDTO, LocalAccountSession, createAppConfig as runtime_createAppConfig } from "../../src";
+import { AppConfig, AppConfigOverwrite, AppRuntime, IUIBridge, LocalAccountDTO, LocalAccountSession, createAppConfig as runtime_createAppConfig } from "../../src";
 import { FakeUIBridge } from "./FakeUIBridge";
 import { FakeNativeBootstrapper } from "./natives/FakeNativeBootstrapper";
 
 export class TestUtil {
-    public static async createRuntime(configOverride?: any, uiBridge: IUIBridge = new FakeUIBridge(), eventBus?: EventBus): Promise<AppRuntime> {
+    public static async createRuntime(configOverride?: AppConfigOverwrite, uiBridge: IUIBridge = new FakeUIBridge(), eventBus?: EventBus): Promise<AppRuntime> {
         configOverride = defaultsDeep(configOverride, {
             modules: {
                 pushNotification: { enabled: false }
@@ -42,7 +42,7 @@ export class TestUtil {
         return runtime;
     }
 
-    public static async createRuntimeWithoutInit(configOverride?: any): Promise<AppRuntime> {
+    public static async createRuntimeWithoutInit(configOverride?: AppConfigOverwrite): Promise<AppRuntime> {
         const config = this.createAppConfig(configOverride);
 
         const nativeBootstrapper = new FakeNativeBootstrapper();

--- a/packages/app-runtime/test/lib/natives/FakeNativeConfigAccess.ts
+++ b/packages/app-runtime/test/lib/natives/FakeNativeConfigAccess.ts
@@ -21,12 +21,4 @@ export class FakeNativeConfigAccess implements INativeConfigAccess {
     public save(): Promise<Result<void>> {
         return Promise.resolve(Result.ok(undefined));
     }
-
-    public initRuntimeConfig(/* logger: ILogger, fileAccess: INativeFileAccess*/): Promise<Result<void>> {
-        return Promise.resolve(Result.ok(undefined));
-    }
-
-    public initDefaultConfig(): Promise<Result<void>> {
-        return Promise.resolve(Result.ok(undefined));
-    }
 }


### PR DESCRIPTION
# Readiness checklist

- [ ] I added/updated tests.
- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

# Description

This PR massively simplifies how to configure the app runtime:

Old:

- setup the native config access
- the native config access tries to resolve many things from the app
- some keys were read from the config acess

New:

- just pass the config to the runtime before startup
