### PR TITLE
Wrong i18n usage

### DIFF
--- a/packages/runtime/src/dataViews/DataViewExpander.ts
+++ b/packages/runtime/src/dataViews/DataViewExpander.ts
@@ -1620,7 +1620,7 @@ export class DataViewExpander {
             id: address,
             name: name ?? "i18n://dvo.identity.unknown",
             initials: name ? (name.match(/\b\w/g) ?? []).join("") : "",
-            description: "i18n://dvo.identity.unknown.description",
+            description: "i18n://dvo.identity.unknown",
             isSelf: false,
             hasRelationship: false
         };

--- a/packages/runtime/src/dataViews/DataViewExpander.ts
+++ b/packages/runtime/src/dataViews/DataViewExpander.ts
@@ -1556,7 +1556,7 @@ export class DataViewExpander {
             type: "IdentityDVO",
             name: "i18n://dvo.identity.unknown",
             initials: "",
-            description: "i18n://dvo.identity.unknown.description",
+            description: "i18n://dvo.identity.unknown",
             publicKey: "i18n://dvo.identity.publicKey.unknown",
             isSelf: false,
             hasRelationship: false


### PR DESCRIPTION
# Readiness checklist

- [ ] I added/updated tests.
- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

# Description

i18n in flutter is json based, and a leaf can not be a branch:

Current usage would need to define such a json:

```
{
    "dvo": {
        "identity": {
            "unknown": "a translation",
            "unknown": {
                "description": "another translation"
            }
        }
    }
}
```

which results in a `Duplicate object key` warning. As the description is not used for unknown identities and the leaf was not definable I just made name = description to fix this.