### PR TITLE
The recovery kit token is not deleted from the backbone after successful onboarding

### DIFF
--- a/packages/app-runtime/src/multiAccount/MultiAccountController.ts
+++ b/packages/app-runtime/src/multiAccount/MultiAccountController.ts
@@ -197,6 +197,18 @@ export class MultiAccountController {
 
         const updatedLocalAccount = await this.updateLocalAccountAddress(localAccount.id, accountController.identity.address);
 
+        if (deviceSharedSecret.isBackupDevice) {
+            const tokens = await accountController.tokens.getTokens({
+                "cache.content.@type": "TokenContentDeviceSharedSecret",
+                "cache.content.sharedSecret.id": deviceSharedSecret.id.toString(),
+                "cache.content.sharedSecret.isBackupDevice": true
+            });
+
+            for (const token of tokens) {
+                await accountController.tokens.delete(token);
+            }
+        }
+
         return [updatedLocalAccount, accountController];
     }
 

--- a/packages/app-runtime/test/runtime/Onboarding.test.ts
+++ b/packages/app-runtime/test/runtime/Onboarding.test.ts
@@ -6,6 +6,7 @@ import { TestUtil } from "../lib";
 describe("Onboarding", function () {
     let runtime: AppRuntime;
     let runtime2: AppRuntime;
+    let runtime3: AppRuntime;
 
     let services1: AppRuntimeServices;
 
@@ -18,6 +19,9 @@ describe("Onboarding", function () {
 
         runtime2 = await TestUtil.createRuntime();
         await runtime2.start();
+
+        runtime3 = await TestUtil.createRuntime();
+        await runtime3.start();
     });
 
     afterAll(async function () {
@@ -49,6 +53,8 @@ describe("Onboarding", function () {
             "Token not found. Make sure the ID exists and the record is not expired. If a password is required to fetch the record, make sure you passed the correct one.",
             "error.runtime.recordNotFound"
         );
+
+        await services1.transportServices.account.syncDatawallet();
     });
 
     test("should onboard with a recovery kit and be able to create a new recovery kit", async () => {
@@ -57,13 +63,13 @@ describe("Onboarding", function () {
             passwordProtection: { password: "aPassword" }
         });
 
-        const token = await runtime2.anonymousServices.tokens.loadPeerToken({ reference: recoveryKitResponse.value.truncatedReference, password: "aPassword" });
+        const token = await runtime3.anonymousServices.tokens.loadPeerToken({ reference: recoveryKitResponse.value.truncatedReference, password: "aPassword" });
         const deviceOnboardingDTO = DeviceMapper.toDeviceOnboardingInfoDTO(DeviceSharedSecret.from(token.value.content.sharedSecret));
 
-        const result = await runtime2.accountServices.onboardAccount(deviceOnboardingDTO);
+        const result = await runtime3.accountServices.onboardAccount(deviceOnboardingDTO);
         expect(result.address!).toBe((await services1.transportServices.account.getIdentityInfo()).value.address);
 
-        const services2 = await runtime2.getServices(result.id);
+        const services2 = await runtime3.getServices(result.id);
 
         await services1.transportServices.account.syncDatawallet();
         const devices = (await services1.transportServices.devices.getDevices()).value;


### PR DESCRIPTION
# Readiness checklist

- [x] I added/updated tests.
- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

# Description

This was designed - but completely forgotten. The app has some pretty ugly issues when scanning a "burned" token, so this is long overdue.
