### PR TITLE
The RequestModule creates expired requests in the `PeerRelationshipTemplateLoaded` event handler

### DIFF
--- a/packages/app-runtime/src/modules/appEvents/RelationshipTemplateProcessedModule.ts
+++ b/packages/app-runtime/src/modules/appEvents/RelationshipTemplateProcessedModule.ts
@@ -70,6 +70,16 @@ export class RelationshipTemplateProcessedModule extends AppRuntimeModule<Relati
                 break;
             }
 
+            case RelationshipTemplateProcessedResult.RequestExpired: {
+                await uiBridge.showError(
+                    new UserfriendlyApplicationError(
+                        "error.relationshipTemplateProcessedModule.requestExpired",
+                        "No incoming request could be created because of the Request in the Template has already expired."
+                    )
+                );
+                break;
+            }
+
             case RelationshipTemplateProcessedResult.RequestAutomaticallyDecided: {
                 break;
             }

--- a/packages/app-runtime/src/modules/appEvents/RelationshipTemplateProcessedModule.ts
+++ b/packages/app-runtime/src/modules/appEvents/RelationshipTemplateProcessedModule.ts
@@ -74,7 +74,7 @@ export class RelationshipTemplateProcessedModule extends AppRuntimeModule<Relati
                 await uiBridge.showError(
                     new UserfriendlyApplicationError(
                         "error.relationshipTemplateProcessedModule.requestExpired",
-                        "No incoming request could be created because of the Request in the Template has already expired."
+                        "No incoming Request could be created because the Request in the RelationshipTemplate is already expired."
                     )
                 );
                 break;

--- a/packages/app-runtime/test/lib/MockUIBridge.matchers.ts
+++ b/packages/app-runtime/test/lib/MockUIBridge.matchers.ts
@@ -107,6 +107,50 @@ expect.extend({
         }
 
         return { pass: true, message: () => "" };
+    },
+    showRequestCalled(mockUIBridge: unknown) {
+        if (!(mockUIBridge instanceof MockUIBridge)) {
+            throw new Error("This method can only be used with expect(MockUIBridge).");
+        }
+
+        const calls = mockUIBridge.calls.filter((x) => x.method === "showRequest");
+        if (calls.length === 0) {
+            return { pass: false, message: () => "The method showRequest was not called." };
+        }
+
+        return { pass: true, message: () => "" };
+    },
+    showRequestNotCalled(mockUIBridge: unknown) {
+        if (!(mockUIBridge instanceof MockUIBridge)) {
+            throw new Error("This method can only be used with expect(MockUIBridge).");
+        }
+
+        const calls = mockUIBridge.calls.filter((x) => x.method === "showRequest");
+        if (calls.length > 0) {
+            return { pass: false, message: () => `The method showRequest called: ${calls.map((c) => `'account id: ${c.account.id} - requestId: ${c.request.id}'`)}` };
+        }
+
+        return { pass: true, message: () => "" };
+    },
+    showErrorCalled(mockUIBridge: unknown, code: string) {
+        if (!(mockUIBridge instanceof MockUIBridge)) {
+            throw new Error("This method can only be used with expect(MockUIBridge).");
+        }
+
+        const errorCalls = mockUIBridge.calls.filter((x) => x.method === "showError");
+        if (errorCalls.length === 0) {
+            return { pass: false, message: () => "The method showError was not called." };
+        }
+
+        const errorCallsWithCode = errorCalls.filter((x) => x.error.code === code);
+        if (errorCallsWithCode.length === 0) {
+            return {
+                pass: false,
+                message: () => `The method showRequest was called but not with the code '${code}' instead with the codes: ${errorCalls.map((c) => `'${c.error.code}'`).join(", ")}`
+            };
+        }
+
+        return { pass: true, message: () => "" };
     }
 });
 
@@ -119,6 +163,9 @@ declare global {
             requestAccountSelectionNotCalled(): R;
             enterPasswordCalled(passwordType: "pw" | "pin", pinLength?: number, attempt?: number): R;
             enterPasswordNotCalled(): R;
+            showRequestCalled(): R;
+            showRequestNotCalled(): R;
+            showErrorCalled(code: string): R;
         }
     }
 }

--- a/packages/app-runtime/test/lib/TestUtil.ts
+++ b/packages/app-runtime/test/lib/TestUtil.ts
@@ -129,17 +129,7 @@ export class TestUtil {
             })
         ).value;
 
-        const tokenFrom = (
-            await from.transportServices.relationshipTemplates.createTokenForOwnTemplate({
-                templateId: templateFrom.id,
-                ephemeral: true,
-                expiresAt: CoreDate.utc().add({ minutes: 5 }).toString()
-            })
-        ).value;
-
-        const templateTo = await to.transportServices.relationshipTemplates.loadPeerRelationshipTemplate({
-            reference: tokenFrom.truncatedReference
-        });
+        const templateTo = await to.transportServices.relationshipTemplates.loadPeerRelationshipTemplate({ reference: templateFrom.truncatedReference });
         return templateTo.value;
     }
 

--- a/packages/app-runtime/test/modules/appEvents/RelationshipTemplateProcessedModule.test.ts
+++ b/packages/app-runtime/test/modules/appEvents/RelationshipTemplateProcessedModule.test.ts
@@ -1,0 +1,72 @@
+import { sleep } from "@js-soft/ts-utils";
+import { AuthenticationRequestItem, RelationshipTemplateContent } from "@nmshd/content";
+import { CoreDate } from "@nmshd/core-types";
+import assert from "assert";
+import { AppRuntime, LocalAccountSession } from "../../../src";
+import { MockEventBus, MockUIBridge, TestUtil } from "../../lib";
+
+describe("RelationshipTemplateProcessedModule", function () {
+    const uiBridge = new MockUIBridge();
+    const eventBus = new MockEventBus();
+
+    let runtime1: AppRuntime;
+    let session1: LocalAccountSession;
+    let session2: LocalAccountSession;
+
+    beforeAll(async function () {
+        runtime1 = await TestUtil.createRuntime(undefined, uiBridge, eventBus);
+        await runtime1.start();
+
+        const [localAccount1, localAccount2] = await TestUtil.provideAccounts(runtime1, 2);
+
+        session1 = await runtime1.selectAccount(localAccount1.id);
+        session2 = await runtime1.selectAccount(localAccount2.id);
+    });
+
+    afterAll(async function () {
+        await runtime1.stop();
+    });
+
+    afterEach(async function () {
+        uiBridge.reset();
+        eventBus.reset();
+
+        const incomingRequests = await session2.consumptionServices.incomingRequests.getRequests({ query: { status: ["Open", "DecisionRequired", "ManualDecisionRequired"] } });
+        for (const request of incomingRequests.value) {
+            const response = await session2.consumptionServices.incomingRequests.reject({ requestId: request.id, items: [{ accept: false }] });
+            assert(response.isSuccess);
+        }
+
+        await eventBus.waitForRunningEventHandlers();
+    });
+
+    test("should show request when RelationshipTemplateProcessedEvent is received with ManualRequestDecisionRequired", async function () {
+        await TestUtil.createAndLoadPeerTemplate(
+            session1,
+            session2,
+            RelationshipTemplateContent.from({ onNewRelationship: { items: [AuthenticationRequestItem.from({ mustBeAccepted: false })] } }).toJSON()
+        );
+        await eventBus.waitForRunningEventHandlers();
+
+        expect(uiBridge).showRequestCalled();
+    });
+
+    test("should show an error when RelationshipTemplateProcessedEvent is received with an expired Request", async function () {
+        const templateFrom = (
+            await session1.transportServices.relationshipTemplates.createOwnRelationshipTemplate({
+                content: RelationshipTemplateContent.from({
+                    onNewRelationship: { expiresAt: CoreDate.utc().add({ seconds: 2 }), items: [AuthenticationRequestItem.from({ mustBeAccepted: false })] }
+                }).toJSON(),
+                expiresAt: CoreDate.utc().add({ minutes: 5 }).toString(),
+                maxNumberOfAllocations: 1
+            })
+        ).value;
+
+        await sleep(3000);
+        await session2.transportServices.relationshipTemplates.loadPeerRelationshipTemplate({ reference: templateFrom.truncatedReference });
+        await eventBus.waitForRunningEventHandlers();
+
+        expect(uiBridge).showRequestNotCalled();
+        expect(uiBridge).showErrorCalled("error.relationshipTemplateProcessedModule.requestExpired");
+    });
+});

--- a/packages/runtime/src/events/consumption/RelationshipTemplateProcessedEvent.ts
+++ b/packages/runtime/src/events/consumption/RelationshipTemplateProcessedEvent.ts
@@ -17,7 +17,8 @@ export enum RelationshipTemplateProcessedResult {
     NonCompletedRequestExists = "NonCompletedRequestExists",
     RelationshipExists = "RelationshipExists",
     NoRequest = "NoRequest",
-    Error = "Error"
+    Error = "Error",
+    RequestExpired = "RequestExpired"
 }
 
 export type RelationshipTemplateProcessedEventData =
@@ -48,4 +49,8 @@ export type RelationshipTemplateProcessedEventData =
     | {
           template: RelationshipTemplateDTO;
           result: RelationshipTemplateProcessedResult.Error;
+      }
+    | {
+          template: RelationshipTemplateDTO;
+          result: RelationshipTemplateProcessedResult.RequestExpired;
       };


### PR DESCRIPTION
# Readiness checklist

- [x] I added/updated tests.
- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

<!-- # Description -->
