### PR TITLE
Notifying about RepositoryAttribute succession isn't possible if additional own shared IdentityAttribute with deletionInfo exsists

### DIFF
--- a/packages/consumption/src/modules/attributes/AttributesController.ts
+++ b/packages/consumption/src/modules/attributes/AttributesController.ts
@@ -980,7 +980,13 @@ export class AttributesController extends ConsumptionBaseController {
             return ValidationResult.error(ConsumptionCoreErrors.attributes.cannotSucceedChildOfComplexAttribute(predecessorId.toString()));
         }
 
-        if (predecessor.hasDeletionInfo() && predecessor.deletionInfo.deletionStatus !== LocalAttributeDeletionStatus.DeletionRequestRejected) {
+        if (
+            predecessor.hasDeletionInfo() &&
+            !(
+                predecessor.deletionInfo.deletionStatus === LocalAttributeDeletionStatus.DeletionRequestRejected ||
+                predecessor.deletionInfo.deletionStatus === LocalAttributeDeletionStatus.DeletionRequestSent
+            )
+        ) {
             return ValidationResult.error(ConsumptionCoreErrors.attributes.cannotSucceedAttributesWithDeletionInfo());
         }
 

--- a/packages/runtime/src/useCases/common/RuntimeErrors.ts
+++ b/packages/runtime/src/useCases/common/RuntimeErrors.ts
@@ -228,13 +228,6 @@ class Attributes {
         );
     }
 
-    public cannotSucceedAttributesWithDeletionInfo(ownSharedIdentityAttributeIds: CoreId[] | string[]): ApplicationError {
-        return new ApplicationError(
-            "error.runtime.attributes.cannotSucceedAttributesWithDeletionInfo",
-            `The own shared IdentityAttribute predecessor(s) ${ownSharedIdentityAttributeIds.map((ownSharedIdentityAttributeId) => `'${ownSharedIdentityAttributeId.toString()}'`).join(", ")} can't be succeeded, since they have a deletionInfo.`
-        );
-    }
-
     public isNotOwnSharedAttribute(attributeId: CoreId | string): ApplicationError {
         return new ApplicationError("error.runtime.attributes.isNotOwnSharedAttribute", `Attribute '${attributeId.toString()}' is not an own shared Attribute.`);
     }
@@ -254,6 +247,13 @@ class Attributes {
         return new ApplicationError(
             "error.runtime.attributes.hasSuccessor",
             `Attribute '${predecessor.id.toString()}' already has a successor ${predecessor.succeededBy?.toString()}.`
+        );
+    }
+
+    public cannotSucceedAttributesWithDeletionInfo(ownSharedIdentityAttributeIds: CoreId[] | string[]): ApplicationError {
+        return new ApplicationError(
+            "error.runtime.attributes.cannotSucceedAttributesWithDeletionInfo",
+            `The own shared IdentityAttribute predecessor(s) ${ownSharedIdentityAttributeIds.map((ownSharedIdentityAttributeId) => `'${ownSharedIdentityAttributeId.toString()}'`).join(", ")} can't be succeeded due to set deletionInfo.`
         );
     }
 

--- a/packages/runtime/src/useCases/common/RuntimeErrors.ts
+++ b/packages/runtime/src/useCases/common/RuntimeErrors.ts
@@ -228,6 +228,13 @@ class Attributes {
         );
     }
 
+    public cannotSucceedAttributesWithDeletionInfo(ownSharedIdentityAttributeIds: CoreId[] | string[]): ApplicationError {
+        return new ApplicationError(
+            "error.runtime.attributes.cannotSucceedAttributesWithDeletionInfo",
+            `The own shared IdentityAttribute predecessor(s) ${ownSharedIdentityAttributeIds.map((ownSharedIdentityAttributeId) => `'${ownSharedIdentityAttributeId.toString()}'`).join(", ")} can't be succeeded, since they have a deletionInfo.`
+        );
+    }
+
     public isNotOwnSharedAttribute(attributeId: CoreId | string): ApplicationError {
         return new ApplicationError("error.runtime.attributes.isNotOwnSharedAttribute", `Attribute '${attributeId.toString()}' is not an own shared Attribute.`);
     }

--- a/packages/runtime/src/useCases/consumption/attributes/NotifyPeerAboutRepositoryAttributeSuccession.ts
+++ b/packages/runtime/src/useCases/consumption/attributes/NotifyPeerAboutRepositoryAttributeSuccession.ts
@@ -54,18 +54,11 @@ export class NotifyPeerAboutRepositoryAttributeSuccessionUseCase extends UseCase
             return Result.fail(RuntimeErrors.attributes.noPreviousVersionOfRepositoryAttributeHasBeenSharedWithPeerBefore(repositoryAttributeSuccessorId, request.peer));
         }
 
-        let ownSharedIdentityAttributePredecessor: LocalAttribute | undefined;
-        for (const candidatePredecessor of candidatePredecessors) {
-            if (
-                !(
-                    candidatePredecessor.deletionInfo?.deletionStatus === LocalAttributeDeletionStatus.DeletedByPeer ||
-                    candidatePredecessor.deletionInfo?.deletionStatus === LocalAttributeDeletionStatus.ToBeDeletedByPeer
-                )
-            ) {
-                ownSharedIdentityAttributePredecessor = candidatePredecessor;
-                break;
-            }
-        }
+        const ownSharedIdentityAttributePredecessor = candidatePredecessors.find(
+            (attribute) =>
+                attribute.deletionInfo?.deletionStatus !== LocalAttributeDeletionStatus.DeletedByPeer &&
+                attribute.deletionInfo?.deletionStatus !== LocalAttributeDeletionStatus.ToBeDeletedByPeer
+        );
 
         if (!ownSharedIdentityAttributePredecessor) {
             return Result.fail(RuntimeErrors.attributes.cannotSucceedAttributesWithDeletionInfo(candidatePredecessors.map((attribute) => attribute.id)));

--- a/packages/runtime/src/useCases/consumption/attributes/NotifyPeerAboutRepositoryAttributeSuccession.ts
+++ b/packages/runtime/src/useCases/consumption/attributes/NotifyPeerAboutRepositoryAttributeSuccession.ts
@@ -59,8 +59,7 @@ export class NotifyPeerAboutRepositoryAttributeSuccessionUseCase extends UseCase
             if (
                 !(
                     candidatePredecessor.deletionInfo?.deletionStatus === LocalAttributeDeletionStatus.DeletedByPeer ||
-                    candidatePredecessor.deletionInfo?.deletionStatus === LocalAttributeDeletionStatus.ToBeDeletedByPeer ||
-                    candidatePredecessor.deletionInfo?.deletionStatus === LocalAttributeDeletionStatus.DeletionRequestSent
+                    candidatePredecessor.deletionInfo?.deletionStatus === LocalAttributeDeletionStatus.ToBeDeletedByPeer
                 )
             ) {
                 ownSharedIdentityAttributePredecessor = candidatePredecessor;

--- a/packages/runtime/src/useCases/consumption/attributes/NotifyPeerAboutRepositoryAttributeSuccession.ts
+++ b/packages/runtime/src/useCases/consumption/attributes/NotifyPeerAboutRepositoryAttributeSuccession.ts
@@ -59,7 +59,8 @@ export class NotifyPeerAboutRepositoryAttributeSuccessionUseCase extends UseCase
             if (
                 !(
                     candidatePredecessor.deletionInfo?.deletionStatus === LocalAttributeDeletionStatus.DeletedByPeer ||
-                    candidatePredecessor.deletionInfo?.deletionStatus === LocalAttributeDeletionStatus.ToBeDeletedByPeer
+                    candidatePredecessor.deletionInfo?.deletionStatus === LocalAttributeDeletionStatus.ToBeDeletedByPeer ||
+                    candidatePredecessor.deletionInfo?.deletionStatus === LocalAttributeDeletionStatus.DeletionRequestSent
                 )
             ) {
                 ownSharedIdentityAttributePredecessor = candidatePredecessor;

--- a/packages/runtime/test/consumption/attributes.test.ts
+++ b/packages/runtime/test/consumption/attributes.test.ts
@@ -1696,6 +1696,31 @@ describe(NotifyPeerAboutRepositoryAttributeSuccessionUseCase.name, () => {
         expect(ownSharedIdentityAttributeVersion2.succeeds).toStrictEqual(ownSharedIdentityAttributeVersion0.id);
     });
 
+    test("should allow to notify about successor if the predecessor was deleted by peer but additional predecessor exists", async () => {
+        const deleteResult = await services2.consumption.attributes.deletePeerSharedAttributeAndNotifyOwner({ attributeId: ownSharedIdentityAttributeVersion0.id });
+        const notificationId = deleteResult.value.notificationId!;
+
+        await syncUntilHasMessageWithNotification(services1.transport, notificationId);
+        await services1.eventBus.waitForEvent(PeerSharedAttributeDeletedByPeerEvent, (e) => {
+            return e.data.id === ownSharedIdentityAttributeVersion0.id;
+        });
+        const updatedOwnSharedIdentityAttribute = (await services1.consumption.attributes.getAttribute({ id: ownSharedIdentityAttributeVersion0.id })).value;
+        expect(updatedOwnSharedIdentityAttribute.deletionInfo?.deletionStatus).toStrictEqual(LocalAttributeDeletionStatus.DeletedByPeer);
+
+        const ownSharedIdentityAttributeVersion0WithoutDeletionInfo = await executeFullShareRepositoryAttributeFlow(
+            services1,
+            services2,
+            ownSharedIdentityAttributeVersion0.shareInfo!.sourceAttribute!
+        );
+
+        const result = await services1.consumption.attributes.notifyPeerAboutRepositoryAttributeSuccession({
+            attributeId: repositoryAttributeVersion2.id,
+            peer: services2.address
+        });
+        expect(result).toBeSuccessful();
+        expect(result.value.predecessor.id).toBe(ownSharedIdentityAttributeVersion0WithoutDeletionInfo.id);
+    });
+
     test("should throw if the predecessor repository attribute was deleted", async () => {
         const repositoryAttributeVersion0 = (await services1.consumption.attributes.getAttribute({ id: ownSharedIdentityAttributeVersion0.shareInfo!.sourceAttribute! })).value;
         await services1.consumption.attributes.deleteRepositoryAttribute({ attributeId: repositoryAttributeVersion0.id });

--- a/packages/runtime/test/consumption/attributes.test.ts
+++ b/packages/runtime/test/consumption/attributes.test.ts
@@ -1735,7 +1735,7 @@ describe(NotifyPeerAboutRepositoryAttributeSuccessionUseCase.name, () => {
             attributeId: repositoryAttributeVersion2.id,
             peer: services2.address
         });
-        expect(notificationResult).toBeAnError(/.*/, "error.consumption.attributes.cannotSucceedAttributesWithDeletionInfo");
+        expect(notificationResult).toBeAnError(/.*/, "error.runtime.attributes.cannotSucceedAttributesWithDeletionInfo");
     });
 
     test("should throw if the same version of the attribute has been notified about already", async () => {


### PR DESCRIPTION
# Readiness checklist

- [x] I added/updated tests.
- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

# Description

Example: An Identity has a RepositoryAttribute and shared it with a peer, but the peer deleted the peer shared Attribute. As a result, the Identity has an own shared IdentityAttribute with `deletionInfo.deletionStatus = DeletedByPeer`. Then, the peer asks for that RepositoryAttribute again and the Identity shares it again. Now, the Identity has two own shared IdentityAttributes, one with deletionInfo and one without it. If the Identity then succeeds the RepositoryAttribute and wants to notify about the succession, it is necessary to chose the own shared IdentityAttribute without deletionInfo as predecessor.