### PR TITLE
Remove `onlyValid` params

### DIFF
--- a/packages/consumption/src/modules/attributes/AttributesController.ts
+++ b/packages/consumption/src/modules/attributes/AttributesController.ts
@@ -117,10 +117,6 @@ export class AttributesController extends ConsumptionBaseController {
         return { $and: [query, hideTechnicalQuery] };
     }
 
-    public async getValidLocalAttributes(query?: any, hideTechnical = false): Promise<LocalAttribute[]> {
-        return await this.getLocalAttributes(query, hideTechnical, true);
-    }
-
     public async executeIQLQuery(query: IIQLQuery): Promise<LocalAttribute[]> {
         /* Fetch subset of attributes relevant for IQL queries. We filter for
          * identity attributes which are not shared. */

--- a/packages/consumption/src/modules/attributes/AttributesController.ts
+++ b/packages/consumption/src/modules/attributes/AttributesController.ts
@@ -79,11 +79,10 @@ export class AttributesController extends ConsumptionBaseController {
         return LocalAttribute.from(result);
     }
 
-    public async getLocalAttributes(query?: any, hideTechnical = false, onlyValid = false): Promise<LocalAttribute[]> {
+    public async getLocalAttributes(query?: any, hideTechnical = false): Promise<LocalAttribute[]> {
         const enrichedQuery = this.enrichQuery(query, hideTechnical);
         const attributes = await this.attributes.find(enrichedQuery);
         const parsed = this.parseArray(attributes, LocalAttribute);
-        if (!onlyValid) return parsed;
 
         const sorted = parsed.sort((a, b) => {
             return a.createdAt.compare(b.createdAt);

--- a/packages/runtime/src/dataViews/DataViewExpander.ts
+++ b/packages/runtime/src/dataViews/DataViewExpander.ts
@@ -1668,7 +1668,7 @@ export class DataViewExpander {
         const relationshipSetting = await this.getRelationshipSettingDVO(relationship);
 
         const stringByType: Record<string, undefined | string> = {};
-        const relationshipAttributesResult = await this.consumption.attributes.getPeerSharedAttributes({ onlyValid: true, peer: relationship.peer });
+        const relationshipAttributesResult = await this.consumption.attributes.getPeerSharedAttributes({ peer: relationship.peer });
         const expandedAttributes = await this.expandLocalAttributeDTOs(relationshipAttributesResult.value);
         const attributesByType: Record<string, undefined | LocalAttributeDVO[]> = {};
         for (const attribute of expandedAttributes) {

--- a/packages/runtime/src/useCases/common/Schemas.ts
+++ b/packages/runtime/src/useCases/common/Schemas.ts
@@ -15522,9 +15522,6 @@ export const GetAttributesRequest: any = {
                 "query": {
                     "$ref": "#/definitions/GetAttributesRequestQuery"
                 },
-                "onlyValid": {
-                    "type": "boolean"
-                },
                 "hideTechnical": {
                     "type": "boolean"
                 }
@@ -15793,9 +15790,6 @@ export const GetOwnSharedAttributesRequest: any = {
                 "peer": {
                     "$ref": "#/definitions/AddressString"
                 },
-                "onlyValid": {
-                    "type": "boolean"
-                },
                 "query": {
                     "$ref": "#/definitions/GetOwnSharedAttributeRequestQuery"
                 },
@@ -16009,9 +16003,6 @@ export const GetPeerSharedAttributesRequest: any = {
             "properties": {
                 "peer": {
                     "$ref": "#/definitions/AddressString"
-                },
-                "onlyValid": {
-                    "type": "boolean"
                 },
                 "query": {
                     "$ref": "#/definitions/GetPeerSharedAttributesRequestQuery"

--- a/packages/runtime/src/useCases/consumption/attributes/GetAttributes.ts
+++ b/packages/runtime/src/useCases/consumption/attributes/GetAttributes.ts
@@ -11,7 +11,6 @@ import { AttributeMapper } from "./AttributeMapper";
 
 export interface GetAttributesRequest {
     query?: GetAttributesRequestQuery;
-    onlyValid?: boolean;
     hideTechnical?: boolean;
 }
 
@@ -131,7 +130,7 @@ export class GetAttributesUseCase extends UseCase<GetAttributesRequest, LocalAtt
         const flattenedQuery = flattenObject(query);
         const dbQuery = GetAttributesUseCase.queryTranslator.parse(flattenedQuery);
 
-        const attributes = await this.attributeController.getLocalAttributes(dbQuery, request.hideTechnical, request.onlyValid);
+        const attributes = await this.attributeController.getLocalAttributes(dbQuery, request.hideTechnical);
 
         return Result.ok(AttributeMapper.toAttributeDTOList(attributes));
     }

--- a/packages/runtime/src/useCases/consumption/attributes/GetOwnSharedAttributes.ts
+++ b/packages/runtime/src/useCases/consumption/attributes/GetOwnSharedAttributes.ts
@@ -10,7 +10,6 @@ import { GetAttributesRequestQuery, GetAttributesUseCase } from "./GetAttributes
 
 export interface GetOwnSharedAttributesRequest {
     peer: AddressString;
-    onlyValid?: boolean;
     query?: GetOwnSharedAttributeRequestQuery;
     hideTechnical?: boolean;
     /**
@@ -65,7 +64,7 @@ export class GetOwnSharedAttributesUseCase extends UseCase<GetOwnSharedAttribute
             dbQuery["succeededBy"] = { $exists: false };
         }
 
-        const attributes = await this.attributeController.getLocalAttributes(dbQuery, request.hideTechnical, request.onlyValid);
+        const attributes = await this.attributeController.getLocalAttributes(dbQuery, request.hideTechnical);
 
         return Result.ok(AttributeMapper.toAttributeDTOList(attributes));
     }

--- a/packages/runtime/src/useCases/consumption/attributes/GetPeerSharedAttributes.ts
+++ b/packages/runtime/src/useCases/consumption/attributes/GetPeerSharedAttributes.ts
@@ -9,7 +9,6 @@ import { GetAttributesRequestQuery, GetAttributesUseCase } from "./GetAttributes
 
 export interface GetPeerSharedAttributesRequest {
     peer: AddressString;
-    onlyValid?: boolean;
     query?: GetPeerSharedAttributesRequestQuery;
     hideTechnical?: boolean;
     /**
@@ -60,7 +59,7 @@ export class GetPeerSharedAttributesUseCase extends UseCase<GetPeerSharedAttribu
             dbQuery["succeededBy"] = { $exists: false };
         }
 
-        const attributes = await this.attributeController.getLocalAttributes(dbQuery, request.hideTechnical, request.onlyValid);
+        const attributes = await this.attributeController.getLocalAttributes(dbQuery, request.hideTechnical);
 
         return Result.ok(AttributeMapper.toAttributeDTOList(attributes));
     }


### PR DESCRIPTION
# Readiness checklist

- [ ] I added/updated tests.
- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

# Description
Because of merging PR https://github.com/nmshd/runtime/pull/420, the parameter `onlyValid` of the `getLocalAttributes` method of the AttributesController is no longer needed.
