### PR TITLE
Generated display name contains the word module

### DIFF
--- a/packages/runtime/src/extensibility/modules/RuntimeModule.ts
+++ b/packages/runtime/src/extensibility/modules/RuntimeModule.ts
@@ -23,7 +23,6 @@ export abstract class RuntimeModule<TConfig extends ModuleConfiguration = Module
 
     public get displayName(): string {
         return this.configuration.displayName ?? this.constructor.name.replace(/Module$/, "").replace(/([a-z0-9])([A-Z])/g, "$1 $2");
-    
     }
 
     public abstract init(): Promise<void> | void;

--- a/packages/runtime/src/extensibility/modules/RuntimeModule.ts
+++ b/packages/runtime/src/extensibility/modules/RuntimeModule.ts
@@ -22,7 +22,8 @@ export abstract class RuntimeModule<TConfig extends ModuleConfiguration = Module
     }
 
     public get displayName(): string {
-        return this.configuration.displayName ?? this.constructor.name.replace(/([a-z0-9])([A-Z])/g, "$1 $2");
+        return this.configuration.displayName ?? this.constructor.name.replace(/Module$/, "").replace(/([a-z0-9])([A-Z])/g, "$1 $2");
+    
     }
 
     public abstract init(): Promise<void> | void;


### PR DESCRIPTION
# Readiness checklist

- [ ] I added/updated tests.
- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

# Description

Sometimes we used "Module" in the display name, in most cases not.
