### PR TITLE
Remove Transport's createDatabase

### DIFF
--- a/packages/app-runtime/src/AppRuntime.ts
+++ b/packages/app-runtime/src/AppRuntime.ts
@@ -72,7 +72,7 @@ export class AppRuntime extends Runtime<AppConfig> {
         return UserfriendlyResult.ok(undefined);
     }
 
-    private lokiConnection: LokiJsConnection;
+    protected override readonly databaseConnection: LokiJsConnection;
     private _multiAccountController: MultiAccountController;
     public get multiAccountController(): MultiAccountController {
         return this._multiAccountController;
@@ -197,7 +197,7 @@ export class AppRuntime extends Runtime<AppConfig> {
     }
 
     protected async initAccount(): Promise<void> {
-        this._multiAccountController = new MultiAccountController(this.transport, this.runtimeConfig, this.lokiConnection, this.sessionStorage);
+        this._multiAccountController = new MultiAccountController(this.transport, this.runtimeConfig, this.databaseConnection, this.sessionStorage);
         await this._multiAccountController.init();
         this._accountServices = new AccountServices(this._multiAccountController);
     }
@@ -230,10 +230,10 @@ export class AppRuntime extends Runtime<AppConfig> {
 
     protected createDatabaseConnection(): Promise<IDatabaseConnection> {
         this.logger.trace("Creating DatabaseConnection to LokiJS");
-        this.lokiConnection = new LokiJsConnection(this.config.databaseFolder, this.nativeEnvironment.databaseFactory);
+        const lokiConnection = new LokiJsConnection(this.config.databaseFolder, this.nativeEnvironment.databaseFactory);
         this.logger.trace("Finished initialization of LokiJS connection.");
 
-        return Promise.resolve(this.lokiConnection);
+        return Promise.resolve(lokiConnection);
     }
 
     private static moduleRegistry: Record<string, IAppRuntimeModuleConstructor | undefined> = {
@@ -284,7 +284,7 @@ export class AppRuntime extends Runtime<AppConfig> {
         const logError = (e: any) => this.logger.error(e);
 
         await super.stop().catch(logError);
-        await this.lokiConnection.close().catch(logError);
+        await this.databaseConnection.close().catch(logError);
     }
 
     private async startAccounts(): Promise<void> {

--- a/packages/app-runtime/src/multiAccount/MultiAccountController.ts
+++ b/packages/app-runtime/src/multiAccount/MultiAccountController.ts
@@ -37,7 +37,7 @@ export class MultiAccountController {
 
     public async init(): Promise<MultiAccountController> {
         this._log.trace("opening accounts DB");
-        this._db = await this.transport.createDatabase(this.config.accountsDbName);
+        this._db = await this.databaseConnection.getDatabase(this.config.accountsDbName);
         this._log.trace("accounts DB opened.");
 
         this._dbClosed = false;
@@ -107,7 +107,7 @@ export class MultiAccountController {
         }
 
         this._log.trace(`Opening DB for account ${localAccount.id}...`);
-        const db = await this.transport.createDatabase(`acc-${localAccount.id.toString()}`);
+        const db = await this.databaseConnection.getDatabase(`acc-${localAccount.id.toString()}`);
         this._log.trace(`DB for account ${id} opened.`);
 
         this._log.trace(`Initializing AccountController for local account ${id}...`);
@@ -185,7 +185,7 @@ export class MultiAccountController {
         this._log.trace("Local account created.");
 
         this._log.trace(`Opening DB for account ${id}...`);
-        const db = await this.transport.createDatabase(`acc-${id.toString()}`);
+        const db = await this.databaseConnection.getDatabase(`acc-${id.toString()}`);
         this._log.trace(`DB for account ${id} opened.`);
 
         this._log.trace(`Initializing AccountController for local account ${id}...`);
@@ -225,7 +225,7 @@ export class MultiAccountController {
         this._log.trace("Local account created.");
 
         this._log.trace(`Opening DB for account ${id}...`);
-        const db = await this.transport.createDatabase(`acc-${id.toString()}`);
+        const db = await this.databaseConnection.getDatabase(`acc-${id.toString()}`);
         this._log.trace(`DB for account ${id} opened.`);
 
         this._log.trace(`Initializing AccountController for local account ${id}...`);

--- a/packages/consumption/test/core/TestUtil.ts
+++ b/packages/consumption/test/core/TestUtil.ts
@@ -140,8 +140,8 @@ export class TestUtil {
     }
 
     public static async provideAccounts(
-        connection: IDatabaseConnection,
         transport: Transport,
+        connection: IDatabaseConnection,
         count: number,
         requestItemProcessors = new Map<RequestItemConstructor, RequestItemProcessorConstructor>(),
         notificationItemProcessors = new Map<NotificationItemConstructor, NotificationItemProcessorConstructor>(),

--- a/packages/consumption/test/core/TestUtil.ts
+++ b/packages/consumption/test/core/TestUtil.ts
@@ -132,15 +132,15 @@ export class TestUtil {
     }
 
     public static createTransport(
-        connection: IDatabaseConnection,
         eventBus: EventBus = new EventEmitter2EventBus(() => {
             // ignore errors
         })
     ): Transport {
-        return new Transport(connection, this.createConfig(), eventBus, loggerFactory);
+        return new Transport(this.createConfig(), eventBus, loggerFactory);
     }
 
     public static async provideAccounts(
+        connection: IDatabaseConnection,
         transport: Transport,
         count: number,
         requestItemProcessors = new Map<RequestItemConstructor, RequestItemProcessorConstructor>(),
@@ -150,7 +150,7 @@ export class TestUtil {
         const accounts = [];
 
         for (let i = 0; i < count; i++) {
-            const account = await this.createAccount(transport, requestItemProcessors, notificationItemProcessors, customConsumptionConfig);
+            const account = await this.createAccount(connection, transport, requestItemProcessors, notificationItemProcessors, customConsumptionConfig);
             accounts.push(account);
         }
 
@@ -158,12 +158,13 @@ export class TestUtil {
     }
 
     private static async createAccount(
+        connection: IDatabaseConnection,
         transport: Transport,
         requestItemProcessors = new Map<RequestItemConstructor, RequestItemProcessorConstructor>(),
         notificationItemProcessors = new Map<NotificationItemConstructor, NotificationItemProcessorConstructor>(),
         customConsumptionConfig?: ConsumptionConfig
     ): Promise<{ accountController: AccountController; consumptionController: ConsumptionController }> {
-        const db = await transport.createDatabase(`x${Math.random().toString(36).substring(7)}`);
+        const db = await connection.getDatabase(`x${Math.random().toString(36).substring(7)}`);
         const accountController = new AccountController(transport, db, transport.config);
         await accountController.init();
 

--- a/packages/consumption/test/modules/attributeListeners/AttributeListenersController.test.ts
+++ b/packages/consumption/test/modules/attributeListeners/AttributeListenersController.test.ts
@@ -24,10 +24,10 @@ describe("AttributeListenersController", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createConnection();
-        transport = TestUtil.createTransport(connection, mockEventBus);
+        transport = TestUtil.createTransport(mockEventBus);
         await transport.init();
 
-        const account = (await TestUtil.provideAccounts(transport, 1))[0];
+        const account = (await TestUtil.provideAccounts(connection, transport, 1))[0];
         ({ accountController: testAccount, consumptionController } = account);
     });
 

--- a/packages/consumption/test/modules/attributeListeners/AttributeListenersController.test.ts
+++ b/packages/consumption/test/modules/attributeListeners/AttributeListenersController.test.ts
@@ -27,7 +27,7 @@ describe("AttributeListenersController", function () {
         transport = TestUtil.createTransport(mockEventBus);
         await transport.init();
 
-        const account = (await TestUtil.provideAccounts(connection, transport, 1))[0];
+        const account = (await TestUtil.provideAccounts(transport, connection, 1))[0];
         ({ accountController: testAccount, consumptionController } = account);
     });
 

--- a/packages/consumption/test/modules/attributes/AttributeTagCollection.test.ts
+++ b/packages/consumption/test/modules/attributes/AttributeTagCollection.test.ts
@@ -52,11 +52,11 @@ describe("AttributeTagCollection", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
 
         await transport.init();
 
-        ({ consumptionController, accountController } = (await TestUtil.provideAccounts(transport, 1))[0]);
+        ({ consumptionController, accountController } = (await TestUtil.provideAccounts(transport, connection, 1))[0]);
 
         const client = consumptionController.attributes["attributeTagClient"];
         mockedClient = spy(client);

--- a/packages/consumption/test/modules/attributes/AttributesController.test.ts
+++ b/packages/consumption/test/modules/attributes/AttributesController.test.ts
@@ -55,10 +55,10 @@ describe("AttributesController", function () {
         transport = TestUtil.createTransport(mockEventBus);
         await transport.init();
 
-        const connectorAccount = (await TestUtil.provideAccounts(connection, transport, 1))[0];
+        const connectorAccount = (await TestUtil.provideAccounts(transport, connection, 1))[0];
         ({ accountController: testAccount, consumptionController } = connectorAccount);
 
-        const appAccount = (await TestUtil.provideAccounts(connection, transport, 1, undefined, undefined, { setDefaultRepositoryAttributes: true }))[0];
+        const appAccount = (await TestUtil.provideAccounts(transport, connection, 1, undefined, undefined, { setDefaultRepositoryAttributes: true }))[0];
         ({ accountController: appTestAccount, consumptionController: appConsumptionController } = appAccount);
     });
 

--- a/packages/consumption/test/modules/attributes/AttributesController.test.ts
+++ b/packages/consumption/test/modules/attributes/AttributesController.test.ts
@@ -52,13 +52,13 @@ describe("AttributesController", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createConnection();
-        transport = TestUtil.createTransport(connection, mockEventBus);
+        transport = TestUtil.createTransport(mockEventBus);
         await transport.init();
 
-        const connectorAccount = (await TestUtil.provideAccounts(transport, 1))[0];
+        const connectorAccount = (await TestUtil.provideAccounts(connection, transport, 1))[0];
         ({ accountController: testAccount, consumptionController } = connectorAccount);
 
-        const appAccount = (await TestUtil.provideAccounts(transport, 1, undefined, undefined, { setDefaultRepositoryAttributes: true }))[0];
+        const appAccount = (await TestUtil.provideAccounts(connection, transport, 1, undefined, undefined, { setDefaultRepositoryAttributes: true }))[0];
         ({ accountController: appTestAccount, consumptionController: appConsumptionController } = appAccount);
     });
 

--- a/packages/consumption/test/modules/attributes/LocalAttributeDeletionInfo.test.ts
+++ b/packages/consumption/test/modules/attributes/LocalAttributeDeletionInfo.test.ts
@@ -20,10 +20,10 @@ describe("LocalAttributeDeletionInfo", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
         await transport.init();
 
-        const account = (await TestUtil.provideAccounts(transport, 1))[0];
+        const account = (await TestUtil.provideAccounts(transport, connection, 1))[0];
         ({ accountController: testAccount, consumptionController } = account);
     });
 

--- a/packages/consumption/test/modules/identityMetadata/IdentityMetadataController.test.ts
+++ b/packages/consumption/test/modules/identityMetadata/IdentityMetadataController.test.ts
@@ -17,11 +17,11 @@ describe("IdentityMetadataController", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createConnection();
-        transport = TestUtil.createTransport(connection, mockEventBus);
+        transport = TestUtil.createTransport(mockEventBus);
 
         await transport.init();
 
-        const account = (await TestUtil.provideAccounts(transport, 1))[0];
+        const account = (await TestUtil.provideAccounts(transport, connection, 1))[0];
         ({ accountController: testAccount, consumptionController } = account);
     });
 

--- a/packages/consumption/test/modules/notifications/NotificationEnd2End.test.ts
+++ b/packages/consumption/test/modules/notifications/NotificationEnd2End.test.ts
@@ -26,10 +26,10 @@ describe("End2End Notification via Messages", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 2);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 2);
 
         ({ accountController: sAccountController, consumptionController: sConsumptionController } = accounts[0]);
         sConsumptionController.notifications["processorRegistry"].registerProcessor(TestNotificationItem, TestNotificationItemProcessor);

--- a/packages/consumption/test/modules/notifications/NotificationsController.test.ts
+++ b/packages/consumption/test/modules/notifications/NotificationsController.test.ts
@@ -20,10 +20,10 @@ describe("End2End Notification via Messages", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 2);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 2);
 
         ({ accountController: sAccountController, consumptionController: sConsumptionController } = accounts[0]);
         sConsumptionController.notifications["processorRegistry"].registerProcessor(TestNotificationItem, TestNotificationItemProcessor);

--- a/packages/consumption/test/modules/notifications/itemProcessors/attributeDeleted/OwnSharedAttributeDeletedByOwnerNotificationItemProcessor.test.ts
+++ b/packages/consumption/test/modules/notifications/itemProcessors/attributeDeleted/OwnSharedAttributeDeletedByOwnerNotificationItemProcessor.test.ts
@@ -25,10 +25,10 @@ describe("OwnSharedAttributeDeletedByPeerNotificationItemProcessor", function ()
 
     beforeAll(async function () {
         connection = await TestUtil.createConnection();
-        transport = TestUtil.createTransport(connection, mockEventBus);
+        transport = TestUtil.createTransport(mockEventBus);
         await transport.init();
 
-        const account = (await TestUtil.provideAccounts(transport, 1))[0];
+        const account = (await TestUtil.provideAccounts(transport, connection, 1))[0];
         ({ accountController: testAccount, consumptionController } = account);
     });
 

--- a/packages/consumption/test/modules/notifications/itemProcessors/attributeDeleted/PeerSharedAttributeDeletedByPeerNotificationItemProcessor.test.ts
+++ b/packages/consumption/test/modules/notifications/itemProcessors/attributeDeleted/PeerSharedAttributeDeletedByPeerNotificationItemProcessor.test.ts
@@ -26,10 +26,10 @@ describe("PeerSharedAttributeDeletedByPeerNotificationItemProcessor", function (
 
     beforeAll(async function () {
         connection = await TestUtil.createConnection();
-        transport = TestUtil.createTransport(connection, mockEventBus);
+        transport = TestUtil.createTransport(mockEventBus);
         await transport.init();
 
-        const account = (await TestUtil.provideAccounts(transport, 1))[0];
+        const account = (await TestUtil.provideAccounts(transport, connection, 1))[0];
         ({ accountController: testAccount, consumptionController } = account);
     });
 

--- a/packages/consumption/test/modules/notifications/itemProcessors/attributeDeleted/ThirdPartyRelationshipAttributeDeletedByPeerNotificationItemProcessor.test.ts
+++ b/packages/consumption/test/modules/notifications/itemProcessors/attributeDeleted/ThirdPartyRelationshipAttributeDeletedByPeerNotificationItemProcessor.test.ts
@@ -25,10 +25,10 @@ describe("ThirdPartyRelationshipAttributeDeletedByPeerNotificationItemProcessor"
 
     beforeAll(async function () {
         connection = await TestUtil.createConnection();
-        transport = TestUtil.createTransport(connection, mockEventBus);
+        transport = TestUtil.createTransport(mockEventBus);
         await transport.init();
 
-        const account = (await TestUtil.provideAccounts(transport, 1))[0];
+        const account = (await TestUtil.provideAccounts(transport, connection, 1))[0];
         ({ accountController: testAccount, consumptionController } = account);
     });
 

--- a/packages/consumption/test/modules/notifications/itemProcessors/attributeSucceeded/PeerSharedAttributeSucceededNotificationItemProcessor.test.ts
+++ b/packages/consumption/test/modules/notifications/itemProcessors/attributeSucceeded/PeerSharedAttributeSucceededNotificationItemProcessor.test.ts
@@ -24,10 +24,10 @@ describe("PeerSharedAttributeSucceededNotificationItemProcessor", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createConnection();
-        transport = TestUtil.createTransport(connection, mockEventBus);
+        transport = TestUtil.createTransport(mockEventBus);
         await transport.init();
 
-        const account = (await TestUtil.provideAccounts(transport, 1))[0];
+        const account = (await TestUtil.provideAccounts(transport, connection, 1))[0];
         ({ accountController: testAccount, consumptionController } = account);
     });
 

--- a/packages/consumption/test/modules/requests/DeleteRequest.test.ts
+++ b/packages/consumption/test/modules/requests/DeleteRequest.test.ts
@@ -19,10 +19,10 @@ describe("Delete requests", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 2);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 2);
 
         ({ accountController: sAccountController, consumptionController: sConsumptionController } = accounts[0]);
         sConsumptionController.incomingRequests["processorRegistry"].registerProcessor(TestRequestItem, TestRequestItemProcessor);

--- a/packages/consumption/test/modules/requests/RequestEnd2End.test.ts
+++ b/packages/consumption/test/modules/requests/RequestEnd2End.test.ts
@@ -29,10 +29,10 @@ describe("End2End Request/Response via Relationship Template", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 2);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 2);
 
         ({ accountController: sAccountController, consumptionController: sConsumptionController } = accounts[0]);
         sConsumptionController.incomingRequests["processorRegistry"].registerProcessor(TestRequestItem, TestRequestItemProcessor);
@@ -162,10 +162,10 @@ describe("End2End Request/Response via Messages", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 2);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 2);
 
         ({ accountController: sAccountController, consumptionController: sConsumptionController } = accounts[0]);
         sConsumptionController.incomingRequests["processorRegistry"].registerProcessor(TestRequestItem, TestRequestItemProcessor);
@@ -312,10 +312,10 @@ describe("End2End Request via Template and Response via Message", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 2);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 2);
 
         ({ accountController: sAccountController, consumptionController: sConsumptionController } = accounts[0]);
         sConsumptionController.incomingRequests["processorRegistry"].registerProcessor(TestRequestItem, TestRequestItemProcessor);

--- a/packages/consumption/test/modules/requests/RequestsIntegrationTest.ts
+++ b/packages/consumption/test/modules/requests/RequestsIntegrationTest.ts
@@ -84,7 +84,7 @@ export class RequestsTestsContext {
         const database = await dbConnection.getDatabase(`x${Math.random().toString(36).substring(7)}`);
         const collection = new SynchronizedCollection(await database.getCollection("Requests"), 0);
 
-        const account = (await TestUtil.provideAccounts(dbConnection, transport, 1))[0];
+        const account = (await TestUtil.provideAccounts(transport, dbConnection, 1))[0];
         context.consumptionController = account.consumptionController;
 
         const processorRegistry = new RequestItemProcessorRegistry(

--- a/packages/consumption/test/modules/requests/RequestsIntegrationTest.ts
+++ b/packages/consumption/test/modules/requests/RequestsIntegrationTest.ts
@@ -75,7 +75,6 @@ export class RequestsTestsContext {
         const context = new RequestsTestsContext();
 
         const transport = await new Transport(
-            dbConnection,
             config,
             new EventEmitter2EventBus(() => {
                 // noop
@@ -85,7 +84,7 @@ export class RequestsTestsContext {
         const database = await dbConnection.getDatabase(`x${Math.random().toString(36).substring(7)}`);
         const collection = new SynchronizedCollection(await database.getCollection("Requests"), 0);
 
-        const account = (await TestUtil.provideAccounts(transport, 1))[0];
+        const account = (await TestUtil.provideAccounts(dbConnection, transport, 1))[0];
         context.consumptionController = account.consumptionController;
 
         const processorRegistry = new RequestItemProcessorRegistry(

--- a/packages/consumption/test/modules/requests/itemProcessors/createAttribute/Context.ts
+++ b/packages/consumption/test/modules/requests/itemProcessors/createAttribute/Context.ts
@@ -1,4 +1,5 @@
 /* eslint-disable jest/no-standalone-expect */
+import { IDatabaseConnection } from "@js-soft/docdb-access-abstractions";
 import {
     AttributeAlreadySharedAcceptResponseItem,
     AttributeSuccessionAcceptResponseItem,
@@ -46,9 +47,9 @@ export class Context {
         this.processor = new CreateAttributeRequestItemProcessor(this.consumptionController);
     }
 
-    public static async init(transport: Transport): Promise<Context> {
+    public static async init(transport: Transport, connection: IDatabaseConnection): Promise<Context> {
         await transport.init();
-        const account = (await TestUtil.provideAccounts(transport, 1))[0];
+        const account = (await TestUtil.provideAccounts(transport, connection, 1))[0];
         return new Context(account.consumptionController);
     }
 

--- a/packages/consumption/test/modules/requests/itemProcessors/createAttribute/CreateAttributeRequestItemProcessor.test.ts
+++ b/packages/consumption/test/modules/requests/itemProcessors/createAttribute/CreateAttributeRequestItemProcessor.test.ts
@@ -19,9 +19,9 @@ describe("CreateAttributeRequestItemProcessor", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
 
-        context = await Context.init(transport);
+        context = await Context.init(transport, connection);
         Given = new GivenSteps(context);
         When = new WhenSteps(context);
         Then = new ThenSteps(context);

--- a/packages/consumption/test/modules/requests/itemProcessors/deleteAttribute/DeleteAttributeRequestItemProcessor.test.ts
+++ b/packages/consumption/test/modules/requests/itemProcessors/deleteAttribute/DeleteAttributeRequestItemProcessor.test.ts
@@ -36,10 +36,10 @@ describe("DeleteAttributeRequestItemProcessor", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 2);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 2);
         ({ accountController, consumptionController } = accounts[0]);
 
         peerAddress = CoreAddress.from("peerAddress");

--- a/packages/consumption/test/modules/requests/itemProcessors/freeText/FreeTextRequestItemProcessor.test.ts
+++ b/packages/consumption/test/modules/requests/itemProcessors/freeText/FreeTextRequestItemProcessor.test.ts
@@ -14,10 +14,10 @@ describe("FreeTextRequestItemProcessor", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
         await transport.init();
 
-        const account = (await TestUtil.provideAccounts(transport, 1))[0];
+        const account = (await TestUtil.provideAccounts(transport, connection, 1))[0];
         consumptionController = account.consumptionController;
 
         processor = new FreeTextRequestItemProcessor(consumptionController);

--- a/packages/consumption/test/modules/requests/itemProcessors/proposeAttribute/ProposeAttributeRequestItemProcessor.test.ts
+++ b/packages/consumption/test/modules/requests/itemProcessors/proposeAttribute/ProposeAttributeRequestItemProcessor.test.ts
@@ -44,10 +44,10 @@ describe("ProposeAttributeRequestItemProcessor", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 2);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 2);
         ({ accountController, consumptionController } = accounts[0]);
 
         processor = new ProposeAttributeRequestItemProcessor(consumptionController);

--- a/packages/consumption/test/modules/requests/itemProcessors/readAttribute/ReadAttributeRequestItemProcessor.test.ts
+++ b/packages/consumption/test/modules/requests/itemProcessors/readAttribute/ReadAttributeRequestItemProcessor.test.ts
@@ -50,10 +50,10 @@ describe("ReadAttributeRequestItemProcessor", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 2);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 2);
         ({ accountController, consumptionController } = accounts[0]);
 
         processor = new ReadAttributeRequestItemProcessor(consumptionController);

--- a/packages/consumption/test/modules/requests/itemProcessors/registerAttributeListener/RegisterAttributeListenerRequestItemProcessor.test.ts
+++ b/packages/consumption/test/modules/requests/itemProcessors/registerAttributeListener/RegisterAttributeListenerRequestItemProcessor.test.ts
@@ -15,10 +15,10 @@ describe("CreateAttributeRequestItemProcessor", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
         await transport.init();
 
-        const account = (await TestUtil.provideAccounts(transport, 1))[0];
+        const account = (await TestUtil.provideAccounts(transport, connection, 1))[0];
         ({ consumptionController } = account);
 
         processor = new RegisterAttributeListenerRequestItemProcessor(consumptionController);

--- a/packages/consumption/test/modules/requests/itemProcessors/shareAttribute/ShareAttributeRequestItemProcessor.test.ts
+++ b/packages/consumption/test/modules/requests/itemProcessors/shareAttribute/ShareAttributeRequestItemProcessor.test.ts
@@ -44,10 +44,10 @@ describe("ShareAttributeRequestItemProcessor", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 2);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 2);
         ({ accountController: testAccount, consumptionController } = accounts[0]);
 
         ({ accountController: thirdPartyTestAccount, consumptionController: thirdPartyConsumptionController } = accounts[1]);

--- a/packages/consumption/test/modules/requests/itemProcessors/transferFileOwnership/TransferFileOwnershipRequestItemProcessor.test.ts
+++ b/packages/consumption/test/modules/requests/itemProcessors/transferFileOwnership/TransferFileOwnershipRequestItemProcessor.test.ts
@@ -26,9 +26,9 @@ describe("TransferFileOwnershipRequestItemProcessor", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createConnection();
-        const transport = TestUtil.createTransport(connection);
+        const transport = TestUtil.createTransport();
         await transport.init();
-        const accounts = await TestUtil.provideAccounts(transport, 3);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 3);
 
         ({ accountController: senderAccountController, consumptionController: senderConsumptionController } = accounts[0]);
         sender = senderAccountController.identity.address;

--- a/packages/consumption/test/modules/requests/itemProcessors/utility/validateAttributeMatchesWithQuery.test.ts
+++ b/packages/consumption/test/modules/requests/itemProcessors/utility/validateAttributeMatchesWithQuery.test.ts
@@ -42,10 +42,10 @@ describe("validateAttributeMatchesWithQuery", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 2);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 2);
         ({ accountController, consumptionController } = accounts[0]);
         recipient = accountController.identity.address;
 

--- a/packages/runtime/test/lib/TestRuntime.ts
+++ b/packages/runtime/test/lib/TestRuntime.ts
@@ -89,7 +89,7 @@ export class TestRuntime extends Runtime {
 
     protected async initAccount(): Promise<void> {
         const randomAccountName = Math.random().toString(36).substring(7);
-        const db = await this.transport.createDatabase(`acc-${randomAccountName}`);
+        const db = await this.dbConnection!.getDatabase(`acc-${randomAccountName}`);
 
         const accountController = await new AccountController(this.transport, db, this.transport.config).init();
 

--- a/packages/runtime/test/misc/DatabaseSchemaUpgrader.test.ts
+++ b/packages/runtime/test/misc/DatabaseSchemaUpgrader.test.ts
@@ -46,7 +46,6 @@ beforeAll(async () => {
     }
 
     const transport = new Transport(
-        databaseConnection,
         { ...RuntimeServiceProvider.defaultConfig.transportLibrary, supportedIdentityVersion: 1, datawalletEnabled: true },
         new EventEmitter2EventBus(() => {
             // noop
@@ -55,7 +54,7 @@ beforeAll(async () => {
     );
 
     const randomAccountName = Math.random().toString(36).substring(7);
-    const db = await transport.createDatabase(`acc-${randomAccountName}`);
+    const db = await databaseConnection.getDatabase(`acc-${randomAccountName}`);
 
     accountController = await new AccountController(transport, db, transport.config).init();
     consumptionController = await new ConsumptionController(transport, accountController, { setDefaultRepositoryAttributes: false }).init();

--- a/packages/transport/src/core/Transport.ts
+++ b/packages/transport/src/core/Transport.ts
@@ -1,4 +1,3 @@
-import { IDatabaseCollectionProvider, IDatabaseConnection } from "@js-soft/docdb-access-abstractions";
 import { ILogger, ILoggerFactory } from "@js-soft/logging-abstractions";
 import { SimpleLoggerFactory } from "@js-soft/simple-logger";
 import { EventBus } from "@js-soft/ts-utils";
@@ -51,8 +50,6 @@ export interface IConfigOverwrite {
 }
 
 export class Transport {
-    private readonly databaseConnection: IDatabaseConnection;
-
     private readonly _config: IConfig;
     public get config(): IConfig {
         return this._config;
@@ -83,13 +80,11 @@ export class Transport {
     };
 
     public constructor(
-        databaseConnection: IDatabaseConnection,
         customConfig: IConfigOverwrite,
         public readonly eventBus: EventBus,
         loggerFactory: ILoggerFactory = new SimpleLoggerFactory(),
         public readonly correlator?: ICorrelator
     ) {
-        this.databaseConnection = databaseConnection;
         this._config = _.defaultsDeep({}, customConfig, Transport.defaultConfig);
 
         TransportLoggerFactory.init(loggerFactory);
@@ -128,9 +123,5 @@ export class Transport {
         log.info("Transport initialized");
 
         return this;
-    }
-
-    public async createDatabase(name: string): Promise<IDatabaseCollectionProvider> {
-        return await this.databaseConnection.getDatabase(name);
     }
 }

--- a/packages/transport/test/core/backbone/Authentication.test.ts
+++ b/packages/transport/test/core/backbone/Authentication.test.ts
@@ -50,11 +50,11 @@ describe("AuthenticationTest", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createDatabaseConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
 
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 1);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 1);
         testAccount = accounts[0];
         interceptor = new RequestInterceptor((testAccount.authenticator as any).authClient);
     });

--- a/packages/transport/test/core/backbone/CorrelationId.test.ts
+++ b/packages/transport/test/core/backbone/CorrelationId.test.ts
@@ -11,9 +11,9 @@ describe("CorrelationId", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createDatabaseConnection();
-        const transport = TestUtil.createTransport(connection, undefined, correlator);
+        const transport = TestUtil.createTransport(undefined, correlator);
         await transport.init();
-        const accounts = await TestUtil.provideAccounts(transport, 1);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 1);
         testAccount = accounts[0];
         interceptor = new RequestInterceptor((testAccount as any).synchronization.client);
     });

--- a/packages/transport/test/core/backbone/Paginator.test.ts
+++ b/packages/transport/test/core/backbone/Paginator.test.ts
@@ -22,11 +22,11 @@ describe("Paginator", function () {
 
         beforeAll(async function () {
             connection = await TestUtil.createDatabaseConnection();
-            transport = TestUtil.createTransport(connection);
+            transport = TestUtil.createTransport();
 
             await transport.init();
 
-            const accounts = await TestUtil.provideAccounts(transport, 1);
+            const accounts = await TestUtil.provideAccounts(transport, connection, 1);
             testAccount = accounts[0];
 
             const buffer = CoreBuffer.fromUtf8("a");

--- a/packages/transport/test/end2end/End2End.test.ts
+++ b/packages/transport/test/end2end/End2End.test.ts
@@ -11,7 +11,7 @@ describe("AccountTest", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createDatabaseConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
         await transport.init();
     });
 
@@ -20,7 +20,7 @@ describe("AccountTest", function () {
     });
 
     test("should close an account", async function () {
-        const account = await TestUtil.createAccount(transport);
+        const account = await TestUtil.createAccount(transport, connection);
         await expect(account.close()).resolves.not.toThrow();
     });
 });
@@ -33,11 +33,11 @@ describe("RelationshipTest: Accept", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createDatabaseConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
 
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 2);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 2);
         from = accounts[0];
         to = accounts[1];
     });
@@ -148,11 +148,11 @@ describe("RelationshipTest: Reject", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createDatabaseConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
 
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 2);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 2);
         from = accounts[0];
         to = accounts[1];
     });
@@ -256,11 +256,11 @@ describe("RelationshipTest: Revoke", function () {
 
     beforeEach(async function () {
         connection = await TestUtil.createDatabaseConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
 
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 2);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 2);
         templator = accounts[0];
         requestor = accounts[1];
     });
@@ -418,11 +418,11 @@ describe("RelationshipTest: Terminate", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createDatabaseConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
 
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 2);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 2);
         from = accounts[0];
         to = accounts[1];
     });
@@ -463,11 +463,11 @@ describe("RelationshipTest: Request Reactivation", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createDatabaseConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
 
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 2);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 2);
         from = accounts[0];
         to = accounts[1];
         relationshipId = (await TestUtil.addRelationship(from, to)).acceptedRelationshipFromSelf.id;
@@ -510,11 +510,11 @@ describe("RelationshipTest: Accept Reactivation", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createDatabaseConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
 
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 2);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 2);
         from = accounts[0];
         to = accounts[1];
         relationshipId = (await TestUtil.addRelationship(from, to)).acceptedRelationshipFromSelf.id;
@@ -558,11 +558,11 @@ describe("RelationshipTest: Reject Reactivation", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createDatabaseConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
 
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 2);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 2);
         from = accounts[0];
         to = accounts[1];
         relationshipId = (await TestUtil.addRelationship(from, to)).acceptedRelationshipFromSelf.id;
@@ -606,11 +606,11 @@ describe("RelationshipTest: Revoke Reactivation", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createDatabaseConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
 
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 2);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 2);
         from = accounts[0];
         to = accounts[1];
         relationshipId = (await TestUtil.addRelationship(from, to)).acceptedRelationshipFromSelf.id;
@@ -653,11 +653,11 @@ describe("RelationshipTest: Decompose", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createDatabaseConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
 
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 2);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 2);
         from = accounts[0];
         to = accounts[1];
     });
@@ -699,11 +699,11 @@ describe("RelationshipTest: validations for non-existent record", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createDatabaseConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
 
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 1);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 1);
         from = accounts[0];
     });
 
@@ -759,11 +759,11 @@ describe("RelationshipTest: validations (on terminated relationship)", function 
 
     beforeAll(async function () {
         connection = await TestUtil.createDatabaseConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
 
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 2);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 2);
         from = accounts[0];
         to = accounts[1];
         relationshipId = (await TestUtil.addRelationship(from, to)).acceptedRelationshipFromSelf.id;
@@ -832,11 +832,11 @@ describe("RelationshipTest: operation executioner validation (on pending relatio
 
     beforeAll(async function () {
         connection = await TestUtil.createDatabaseConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
 
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 2);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 2);
         from = accounts[0];
         to = accounts[1];
 
@@ -908,11 +908,11 @@ describe("RelationshipTest: relationship status validation (on active relationsh
 
     beforeAll(async function () {
         connection = await TestUtil.createDatabaseConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
 
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 2);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 2);
         from = accounts[0];
         to = accounts[1];
         relationshipId = (await TestUtil.addRelationship(from, to)).acceptedRelationshipFromSelf.id;
@@ -966,11 +966,11 @@ describe("MessageTest", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createDatabaseConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
 
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 2);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 2);
 
         from = accounts[0];
         to = accounts[1];
@@ -1002,11 +1002,11 @@ describe("TokenTest", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createDatabaseConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
 
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 1);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 1);
         from = accounts[0];
     });
 
@@ -1037,11 +1037,11 @@ describe("FileTest", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createDatabaseConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
 
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 2);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 2);
 
         from = accounts[0];
         to = accounts[1];

--- a/packages/transport/test/modules/PublicAPI.test.ts
+++ b/packages/transport/test/modules/PublicAPI.test.ts
@@ -181,11 +181,11 @@ describe("PublicAPI", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createDatabaseConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
 
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 1);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 1);
         account = accounts[0];
         controllers[AccountController.name] = account;
         controllers[DeviceController.name] = account.activeDevice;

--- a/packages/transport/test/modules/TimeSync.test.ts
+++ b/packages/transport/test/modules/TimeSync.test.ts
@@ -15,12 +15,12 @@ describe("TimeSyncTest", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createDatabaseConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
 
         await transport.init();
 
         localTime = CoreDate.utc();
-        const accounts = await TestUtil.provideAccounts(transport, 1);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 1);
         recipient = accounts[0];
         serverTime = recipient.activeDevice.createdAt;
     });

--- a/packages/transport/test/modules/account/AccountController.test.ts
+++ b/packages/transport/test/modules/account/AccountController.test.ts
@@ -11,11 +11,11 @@ describe("AccountController", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createDatabaseConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
 
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 1);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 1);
         account = accounts[0];
     });
 

--- a/packages/transport/test/modules/account/IdentityController.test.ts
+++ b/packages/transport/test/modules/account/IdentityController.test.ts
@@ -10,11 +10,11 @@ describe("IdentityController", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createDatabaseConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
 
         await transport.init();
 
-        [account1, account2] = await TestUtil.provideAccounts(transport, 2);
+        [account1, account2] = await TestUtil.provideAccounts(transport, connection, 2);
         await account1.init();
         await account2.init();
     });

--- a/packages/transport/test/modules/account/IdentityDeletionProcessController.test.ts
+++ b/packages/transport/test/modules/account/IdentityDeletionProcessController.test.ts
@@ -10,11 +10,11 @@ describe("IdentityDeletionProcessController", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createDatabaseConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
 
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 1);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 1);
         account = accounts[0];
         await account.init();
     });
@@ -81,11 +81,11 @@ describe("IdentityDeletionProcessController", function () {
         await connection.close();
 
         connection = await TestUtil.createDatabaseConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
 
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 1);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 1);
         account = accounts[0];
         await account.init();
 

--- a/packages/transport/test/modules/backboneCompatibility/BackboneCompatibilityController.test.ts
+++ b/packages/transport/test/modules/backboneCompatibility/BackboneCompatibilityController.test.ts
@@ -10,7 +10,7 @@ describe("BackboneCompatibility", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createDatabaseConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
 
         await transport.init();
 

--- a/packages/transport/test/modules/certificates/CertificateIssuer.test.ts
+++ b/packages/transport/test/modules/certificates/CertificateIssuer.test.ts
@@ -13,11 +13,11 @@ describe("CertificateIssuer", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createDatabaseConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
 
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 2);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 2);
         issuer = accounts[0];
         subject = accounts[1];
     });

--- a/packages/transport/test/modules/challenges/Challenges.test.ts
+++ b/packages/transport/test/modules/challenges/Challenges.test.ts
@@ -15,11 +15,11 @@ describe("ChallengeTest", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createDatabaseConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
 
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 2);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 2);
 
         sender = accounts[0];
         recipient = accounts[1];

--- a/packages/transport/test/modules/files/FileController.test.ts
+++ b/packages/transport/test/modules/files/FileController.test.ts
@@ -43,11 +43,11 @@ describe("FileController", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createDatabaseConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
 
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 2);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 2);
         sender = accounts[0];
         recipient = accounts[1];
     });

--- a/packages/transport/test/modules/messages/Attachment.test.ts
+++ b/packages/transport/test/modules/messages/Attachment.test.ts
@@ -21,11 +21,11 @@ describe("AttachmentTest", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createDatabaseConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
 
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 3);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 3);
 
         content = CoreBuffer.fromUtf8("abcd");
         content2 = CoreBuffer.fromUtf8("dcbadcba");

--- a/packages/transport/test/modules/messages/ListRelationshipMessages.test.ts
+++ b/packages/transport/test/modules/messages/ListRelationshipMessages.test.ts
@@ -12,10 +12,10 @@ describe("List Relationship Messages", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createDatabaseConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 3);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 3);
 
         recipient = accounts[0];
         sender1 = accounts[1];

--- a/packages/transport/test/modules/messages/MessageContent.test.ts
+++ b/packages/transport/test/modules/messages/MessageContent.test.ts
@@ -14,11 +14,11 @@ describe("MessageContent", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createDatabaseConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
 
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 3);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 3);
 
         recipient1 = accounts[0];
         recipient2 = accounts[1];

--- a/packages/transport/test/modules/messages/MessageController.test.ts
+++ b/packages/transport/test/modules/messages/MessageController.test.ts
@@ -42,11 +42,11 @@ describe("MessageController", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createDatabaseConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
 
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 4);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 4);
         sender = accounts[0];
         recipient = accounts[1];
         recipient2 = accounts[2];

--- a/packages/transport/test/modules/publicRelationshipTemplateReferences/PublicRelationshipTemplateReferencesController.test.ts
+++ b/packages/transport/test/modules/publicRelationshipTemplateReferences/PublicRelationshipTemplateReferencesController.test.ts
@@ -11,11 +11,11 @@ let mockedClient: PublicRelationshipTemplateReferenceClient;
 
 beforeAll(async function () {
     connection = await TestUtil.createDatabaseConnection();
-    transport = TestUtil.createTransport(connection);
+    transport = TestUtil.createTransport();
 
     await transport.init();
 
-    const accounts = await TestUtil.provideAccounts(transport, 1);
+    const accounts = await TestUtil.provideAccounts(transport, connection, 1);
 
     account = accounts[0];
 

--- a/packages/transport/test/modules/relationshipTemplates/RelationshipTemplateController.test.ts
+++ b/packages/transport/test/modules/relationshipTemplates/RelationshipTemplateController.test.ts
@@ -29,11 +29,11 @@ describe("RelationshipTemplateController", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createDatabaseConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
 
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 2);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 2);
         sender = accounts[0];
         recipient = accounts[1];
     });

--- a/packages/transport/test/modules/relationships/RejectAccept.test.ts
+++ b/packages/transport/test/modules/relationships/RejectAccept.test.ts
@@ -12,11 +12,11 @@ describe("Reject and accept relationship / send message", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createDatabaseConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
 
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 2);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 2);
         sender = accounts[0];
         recipient = accounts[1];
 

--- a/packages/transport/test/modules/relationships/RelationshipsController.test.ts
+++ b/packages/transport/test/modules/relationships/RelationshipsController.test.ts
@@ -37,11 +37,11 @@ describe("RelationshipsController", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createDatabaseConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
 
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 4);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 4);
         sender = accounts[0];
         recipient1 = accounts[1];
         recipient2 = accounts[2];

--- a/packages/transport/test/modules/relationships/RelationshipsCustomContent.test.ts
+++ b/packages/transport/test/modules/relationships/RelationshipsCustomContent.test.ts
@@ -13,11 +13,11 @@ describe("Relationships Custom Content", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createDatabaseConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
 
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 2);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 2);
         sender = accounts[0];
         recipient = accounts[1];
     });

--- a/packages/transport/test/modules/relationships/TerminateDecompose.test.ts
+++ b/packages/transport/test/modules/relationships/TerminateDecompose.test.ts
@@ -15,11 +15,11 @@ describe("Terminate and Decompose simultaneously", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createDatabaseConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
 
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 2);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 2);
         sender = accounts[0];
         recipient = accounts[1];
 

--- a/packages/transport/test/modules/relationships/decomposition.test.ts
+++ b/packages/transport/test/modules/relationships/decomposition.test.ts
@@ -21,11 +21,11 @@ describe("Data cleanup after relationship decomposition", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createDatabaseConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
 
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 3);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 3);
         sender = accounts[0];
         recipient1 = accounts[1];
         recipient2 = accounts[2];
@@ -90,7 +90,7 @@ describe("Data cleanup after relationship decomposition", function () {
             datawalletEnabled: true
         });
 
-        const accounts = await TestUtil.provideAccounts(transport, 2);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 2);
         const recipient1 = accounts[0];
         const recipient2 = accounts[1];
 
@@ -128,11 +128,11 @@ describe("Relationship decomposition due to Identity deletion", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createDatabaseConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
 
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 2);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 2);
         sender = accounts[0];
         recipient = accounts[1];
 

--- a/packages/transport/test/modules/secrets/SecretController.test.ts
+++ b/packages/transport/test/modules/secrets/SecretController.test.ts
@@ -16,11 +16,11 @@ let secretController: SecretController;
 describe("SecretController", function () {
     beforeAll(async function () {
         connection = await TestUtil.createDatabaseConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
 
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 2);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 2);
         account = accounts[0];
         subject = accounts[1];
         secretController = await new SecretController(account).init();

--- a/packages/transport/test/modules/sync/SyncController.ordered.test.ts
+++ b/packages/transport/test/modules/sync/SyncController.ordered.test.ts
@@ -14,11 +14,11 @@ describe("SyncController.ordered", function () {
     beforeAll(async function () {
         connection = await TestUtil.createDatabaseConnection();
 
-        transport = TestUtil.createTransport(connection, { datawalletEnabled: true });
+        transport = TestUtil.createTransport({ datawalletEnabled: true });
         await transport.init();
 
-        sender = await TestUtil.createAccount(transport);
-        recipient = await TestUtil.createAccount(transport);
+        sender = await TestUtil.createAccount(transport, connection);
+        recipient = await TestUtil.createAccount(transport, connection);
     });
 
     afterAll(async () => {
@@ -43,6 +43,6 @@ describe("SyncController.ordered", function () {
         // onboard a second device for the recipient
         const newDevice = await recipient!.devices.sendDevice({ name: "Test2", isAdmin: true });
         await recipient!.syncDatawallet();
-        recipientSecondDevice = await TestUtil.onboardDevice(transport, await recipient!.devices.getSharedSecret(newDevice.id));
+        recipientSecondDevice = await TestUtil.onboardDevice(transport, connection, await recipient!.devices.getSharedSecret(newDevice.id));
     });
 });

--- a/packages/transport/test/modules/sync/SyncController.test.ts
+++ b/packages/transport/test/modules/sync/SyncController.test.ts
@@ -14,7 +14,7 @@ describe("SyncController", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createDatabaseConnection();
-        transport = TestUtil.createTransport(connection, { datawalletEnabled: true });
+        transport = TestUtil.createTransport({ datawalletEnabled: true });
 
         await transport.init();
     });
@@ -29,7 +29,7 @@ describe("SyncController", function () {
     test("creating a new identity sets the identityDatawalletVersion to the supportedDatawalletVersion", async function () {
         const syncClient = new FakeSyncClient();
 
-        const account = await TestUtil.createAccount(transport, { syncClient });
+        const account = await TestUtil.createAccount(transport, connection, { syncClient });
 
         expect(syncClient.finalizeDatawalletVersionUpgradeRequest).toBeDefined();
         expect(syncClient.finalizeDatawalletVersionUpgradeRequest!.newDatawalletVersion).toStrictEqual(account.config.supportedDatawalletVersion);
@@ -38,7 +38,7 @@ describe("SyncController", function () {
     test("all datawallet modifications are created with the configured supportedDatawalletVersion", async function () {
         const syncClient = new FakeSyncClient();
 
-        const account = await TestUtil.createAccount(transport, { syncClient });
+        const account = await TestUtil.createAccount(transport, connection, { syncClient });
 
         await account.tokens.sendToken({
             content: { someProperty: "someValue" },
@@ -58,7 +58,7 @@ describe("SyncController", function () {
     test("syncDatawallet upgrades identityDatawalletVersion to supportedDatawalletVersion", async function () {
         const syncClient = new FakeSyncClient();
 
-        const account = await TestUtil.createAccount(transport, { syncClient });
+        const account = await TestUtil.createAccount(transport, connection, { syncClient });
 
         TestUtil.defineMigrationToVersion(2, account);
 
@@ -72,7 +72,7 @@ describe("SyncController", function () {
     });
 
     test("sync should return existing promise when called twice", async function () {
-        const [sender, recipient] = await TestUtil.provideAccounts(transport, 2);
+        const [sender, recipient] = await TestUtil.provideAccounts(transport, connection, 2);
         await TestUtil.addRelationship(sender, recipient);
 
         await TestUtil.sendMessage(sender, recipient);

--- a/packages/transport/test/modules/sync/externalEventProcessors/PeerDeletedExternalEventProcessor.test.ts
+++ b/packages/transport/test/modules/sync/externalEventProcessors/PeerDeletedExternalEventProcessor.test.ts
@@ -16,11 +16,11 @@ describe("PeerDeletedExternalEventProcessor", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createDatabaseConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
 
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 2);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 2);
         sender = accounts[0];
         recipient = accounts[1];
         relationshipId = (await TestUtil.addRelationship(sender, recipient)).acceptedRelationshipFromSelf.id;

--- a/packages/transport/test/modules/sync/externalEventProcessors/PeerDeletionCancelledExternalEvent.test.ts
+++ b/packages/transport/test/modules/sync/externalEventProcessors/PeerDeletionCancelledExternalEvent.test.ts
@@ -16,11 +16,11 @@ describe("PeerDeletionCancelledExternalEventProcessor", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createDatabaseConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
 
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 2);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 2);
         sender = accounts[0];
         recipient = accounts[1];
         relationshipId = (await TestUtil.addRelationship(sender, recipient)).acceptedRelationshipFromSelf.id;

--- a/packages/transport/test/modules/sync/externalEventProcessors/PeerToBeDeletedExternalEventProcessor.test.ts
+++ b/packages/transport/test/modules/sync/externalEventProcessors/PeerToBeDeletedExternalEventProcessor.test.ts
@@ -16,11 +16,11 @@ describe("PeerToBeDeletedExternalEventProcessor", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createDatabaseConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
 
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 2);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 2);
         sender = accounts[0];
         recipient = accounts[1];
         relationshipId = (await TestUtil.addRelationship(sender, recipient)).acceptedRelationshipFromSelf.id;

--- a/packages/transport/test/modules/tokens/AnonymousTokenController.test.ts
+++ b/packages/transport/test/modules/tokens/AnonymousTokenController.test.ts
@@ -31,11 +31,11 @@ describe("AnonymousTokenController", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createDatabaseConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
 
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 1);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 1);
         sender = accounts[0];
 
         anonymousTokenController = new AnonymousTokenController(transport.config);

--- a/packages/transport/test/modules/tokens/TokenContent.test.ts
+++ b/packages/transport/test/modules/tokens/TokenContent.test.ts
@@ -13,11 +13,11 @@ describe("TokenContent", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createDatabaseConnection();
-        transport = TestUtil.createTransport(connection, { datawalletEnabled: true });
+        transport = TestUtil.createTransport({ datawalletEnabled: true });
 
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 3);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 3);
 
         account = accounts[0];
     });
@@ -232,7 +232,7 @@ describe("TokenContent", function () {
             expect(deserialized).toBeInstanceOf(Serializable);
             expect(deserialized).toBeInstanceOf(TokenContentDeviceSharedSecret);
             expect(deserialized.sharedSecret).toBeInstanceOf(DeviceSharedSecret);
-            await TestUtil.onboardDevice(transport, deserialized.sharedSecret);
+            await TestUtil.onboardDevice(transport, connection, deserialized.sharedSecret);
         });
 
         test("should serialize and deserialize correctly (no type information)", async function () {
@@ -255,7 +255,7 @@ describe("TokenContent", function () {
             expect(deserialized).toBeInstanceOf(Serializable);
             expect(deserialized).toBeInstanceOf(TokenContentDeviceSharedSecret);
             expect(deserialized.sharedSecret).toBeInstanceOf(DeviceSharedSecret);
-            await TestUtil.onboardDevice(transport, deserialized.sharedSecret);
+            await TestUtil.onboardDevice(transport, connection, deserialized.sharedSecret);
         });
 
         test("should serialize and deserialize correctly (from unknown type)", async function () {
@@ -279,7 +279,7 @@ describe("TokenContent", function () {
             expect(deserialized).toBeInstanceOf(Serializable);
             expect(deserialized).toBeInstanceOf(TokenContentDeviceSharedSecret);
             expect(deserialized.sharedSecret).toBeInstanceOf(DeviceSharedSecret);
-            await TestUtil.onboardDevice(transport, deserialized.sharedSecret);
+            await TestUtil.onboardDevice(transport, connection, deserialized.sharedSecret);
         });
     });
 

--- a/packages/transport/test/modules/tokens/TokenController.test.ts
+++ b/packages/transport/test/modules/tokens/TokenController.test.ts
@@ -35,11 +35,11 @@ describe("TokenController", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createDatabaseConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
 
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 2);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 2);
         sender = accounts[0];
         recipient = accounts[1];
     });

--- a/packages/transport/test/performance/PerformanceOpenRequests.test.ts
+++ b/packages/transport/test/performance/PerformanceOpenRequests.test.ts
@@ -10,11 +10,11 @@ describe("Performant Fetch of Open Requests", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createDatabaseConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
 
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 1);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 1);
 
         recipient = accounts[0];
     });

--- a/packages/transport/test/performance/PerformanceRelationships.test.ts
+++ b/packages/transport/test/performance/PerformanceRelationships.test.ts
@@ -12,11 +12,11 @@ describe("List Relationship Messages", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createDatabaseConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
 
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 3);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 3);
 
         recipient = accounts[0];
         sender1 = accounts[1];

--- a/packages/transport/test/performance/PerformanceTemplates.test.ts
+++ b/packages/transport/test/performance/PerformanceTemplates.test.ts
@@ -22,11 +22,11 @@ describe("Performant Creation of Templates", function () {
 
     beforeAll(async function () {
         connection = await TestUtil.createDatabaseConnection();
-        transport = TestUtil.createTransport(connection);
+        transport = TestUtil.createTransport();
 
         await transport.init();
 
-        const accounts = await TestUtil.provideAccounts(transport, 1);
+        const accounts = await TestUtil.provideAccounts(transport, connection, 1);
 
         recipient = accounts[0];
     });

--- a/packages/transport/test/testHelpers/AppDeviceTest.ts
+++ b/packages/transport/test/testHelpers/AppDeviceTest.ts
@@ -15,7 +15,6 @@ export class AppDeviceTest {
     public constructor(parameters: DeviceTestParameters) {
         this.parameters = parameters;
         this.transport = new Transport(
-            this.parameters.connection,
             this.parameters.config,
             new EventEmitter2EventBus(() => {
                 // ignore errors
@@ -29,7 +28,7 @@ export class AppDeviceTest {
     }
 
     public async createAccount(): Promise<AccountController> {
-        const accounts = await TestUtil.provideAccounts(this.transport, 1);
+        const accounts = await TestUtil.provideAccounts(this.transport, this.parameters.connection, 1);
 
         const account = accounts[0];
 
@@ -38,7 +37,7 @@ export class AppDeviceTest {
     }
 
     public async onboardDevice(sharedSecret: DeviceSharedSecret): Promise<AccountController> {
-        const account = await TestUtil.onboardDevice(this.transport, sharedSecret);
+        const account = await TestUtil.onboardDevice(this.transport, this.parameters.connection, sharedSecret);
         this.createdAccounts.push(account);
         return account;
     }

--- a/packages/transport/test/testHelpers/TestUtil.ts
+++ b/packages/transport/test/testHelpers/TestUtil.ts
@@ -214,7 +214,7 @@ export class TestUtil {
         device1: AccountController;
         device2: AccountController;
     }> {
-        // Create Device1 Controller    transport = TestUtil.createTransport(connection);
+        // Create Device1 Controller    transport = TestUtil.createTransport();
         const transport = TestUtil.createTransport(config);
 
         await transport.init();


### PR DESCRIPTION
# Readiness checklist

- [ ] I added/updated tests.
- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

# Description

That function was misleading (calling getDatabase underneath) and unnecessary.

Additionally it get's in the right direction to remove the Transport object completely.
