### PR TITLE
`lastAccessedAt` of all accounts is overwritten on AppRuntime startup

### DIFF
--- a/packages/app-runtime/src/AppRuntime.ts
+++ b/packages/app-runtime/src/AppRuntime.ts
@@ -291,7 +291,7 @@ export class AppRuntime extends Runtime<AppConfig> {
         const accounts = await this._multiAccountController.getAccounts();
 
         for (const account of accounts) {
-            const session = await this.selectAccount(account.id.toString());
+            const session = await this.getOrCreateSession(account.id.toString());
 
             session.accountController.authenticator.clear();
             try {


### PR DESCRIPTION
# Readiness checklist

- [ ] I added/updated tests.
- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

<!-- # Description -->
