### PR TITLE
Allow longer tags

### DIFF
--- a/packages/content/src/attributes/IdentityAttribute.ts
+++ b/packages/content/src/attributes/IdentityAttribute.ts
@@ -44,7 +44,7 @@ export class IdentityAttribute<TValueClass extends AttributeValues.Identity.Clas
         }
 
         if (tags.some((tag) => tag.length > 250)) {
-            return "The maximum length of a tag is 100 characters.";
+            return "The maximum length of a tag is 250 characters.";
         }
 
         return undefined;

--- a/packages/content/src/attributes/IdentityAttribute.ts
+++ b/packages/content/src/attributes/IdentityAttribute.ts
@@ -43,7 +43,7 @@ export class IdentityAttribute<TValueClass extends AttributeValues.Identity.Clas
             return "The maximum number of tags is 20.";
         }
 
-        if (tags.some((tag) => tag.length > 100)) {
+        if (tags.some((tag) => tag.length > 250)) {
             return "The maximum length of a tag is 100 characters.";
         }
 

--- a/packages/content/src/attributes/IdentityAttributeQuery.ts
+++ b/packages/content/src/attributes/IdentityAttributeQuery.ts
@@ -52,7 +52,7 @@ export class IdentityAttributeQuery extends AbstractAttributeQuery implements II
         }
 
         if (tags.some((tag) => tag.length > 250)) {
-            return "The maximum length of a tag is 100 characters.";
+            return "The maximum length of a tag is 250 characters.";
         }
 
         return undefined;

--- a/packages/content/src/attributes/IdentityAttributeQuery.ts
+++ b/packages/content/src/attributes/IdentityAttributeQuery.ts
@@ -51,7 +51,7 @@ export class IdentityAttributeQuery extends AbstractAttributeQuery implements II
             return "The maximum number of tags is 20.";
         }
 
-        if (tags.some((tag) => tag.length > 100)) {
+        if (tags.some((tag) => tag.length > 250)) {
             return "The maximum length of a tag is 100 characters.";
         }
 


### PR DESCRIPTION
# Readiness checklist

- [ ] I added/updated tests.
- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

# Description

This allows tags like `urn:xbildung-de:destatis:codeliste:artdesschulabschlusses=http://xbildung.de/def/destatis/1.0/code/artdesschulabschlusses/allgemeine_hochschulreife`
