### PR TITLE
The validation error message includes the indices of the valid strings

### DIFF
--- a/packages/runtime/src/useCases/common/validation/TokenAndTemplateCreationValidator.ts
+++ b/packages/runtime/src/useCases/common/validation/TokenAndTemplateCreationValidator.ts
@@ -47,8 +47,8 @@ export class TokenAndTemplateCreationValidator<
                 validationResult.addFailure(
                     new ValidationFailure(
                         RuntimeErrors.general.invalidPropertyValue(
-                            `must be a number from 50 to 99 or one of the following strings: ${Object.values(PasswordLocationIndicatorOptions)
-                                .filter((value) => value !== "RecoveryKit")
+                            `must be a number from 50 to 99 or one of the following strings: ${Object.keys(PasswordLocationIndicatorOptions)
+                                .filter((key) => isNaN(Number(key)) && key !== "RecoveryKit")
                                 .join(", ")}`
                         ),
                         "passwordLocationIndicator"


### PR DESCRIPTION
# Readiness checklist

- [ ] I added/updated tests.
- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

# Description

Former error message: `must be a number from 50 to 99 or one of the following strings: Self, Letter, RegistrationLetter, Email, SMS, Website, 0, 1, 2, 3, 4, 5, 6`. This seems to have slipped through the tests, since it appends something to the checked string.