### PR TITLE
Add validateTagsForType

### DIFF
--- a/packages/consumption/src/modules/requests/itemProcessors/createAttribute/CreateAttributeRequestItemProcessor.ts
+++ b/packages/consumption/src/modules/requests/itemProcessors/createAttribute/CreateAttributeRequestItemProcessor.ts
@@ -41,7 +41,7 @@ export class CreateAttributeRequestItemProcessor extends GenericRequestItemProce
                 );
             }
 
-            const tagValidationResult = await this.consumptionController.attributes.validateTags(requestItem.attribute);
+            const tagValidationResult = await this.consumptionController.attributes.validateTagsOfAttribute(requestItem.attribute);
             if (tagValidationResult.isError()) {
                 return ValidationResult.error(ConsumptionCoreErrors.requests.invalidRequestItem(tagValidationResult.error.message));
             }
@@ -103,7 +103,7 @@ export class CreateAttributeRequestItemProcessor extends GenericRequestItemProce
             }
         }
 
-        const tagValidationResult = await this.consumptionController.attributes.validateTags(requestItem.attribute);
+        const tagValidationResult = await this.consumptionController.attributes.validateTagsOfAttribute(requestItem.attribute);
         if (tagValidationResult.isError()) {
             return ValidationResult.error(ConsumptionCoreErrors.requests.invalidRequestItem(tagValidationResult.error.message));
         }

--- a/packages/consumption/src/modules/requests/itemProcessors/proposeAttribute/ProposeAttributeRequestItemProcessor.ts
+++ b/packages/consumption/src/modules/requests/itemProcessors/proposeAttribute/ProposeAttributeRequestItemProcessor.ts
@@ -77,7 +77,7 @@ export class ProposeAttributeRequestItemProcessor extends GenericRequestItemProc
             );
         }
 
-        const tagValidationResult = await this.consumptionController.attributes.validateTags(attribute);
+        const tagValidationResult = await this.consumptionController.attributes.validateTagsOfAttribute(attribute);
         if (tagValidationResult.isError()) {
             return ValidationResult.error(ConsumptionCoreErrors.requests.invalidRequestItem(tagValidationResult.error.message));
         }
@@ -217,7 +217,7 @@ export class ProposeAttributeRequestItemProcessor extends GenericRequestItemProc
             }
         }
 
-        const tagValidationResult = await this.consumptionController.attributes.validateTags(attribute);
+        const tagValidationResult = await this.consumptionController.attributes.validateTagsOfAttribute(attribute);
         if (tagValidationResult.isError()) {
             return ValidationResult.error(ConsumptionCoreErrors.requests.invalidAcceptParameters(tagValidationResult.error.message));
         }

--- a/packages/consumption/src/modules/requests/itemProcessors/readAttribute/ReadAttributeRequestItemProcessor.ts
+++ b/packages/consumption/src/modules/requests/itemProcessors/readAttribute/ReadAttributeRequestItemProcessor.ts
@@ -262,7 +262,7 @@ export class ReadAttributeRequestItemProcessor extends GenericRequestItemProcess
             );
         }
 
-        const tagValidationResult = await this.consumptionController.attributes.validateTags(attribute);
+        const tagValidationResult = await this.consumptionController.attributes.validateTagsOfAttribute(attribute);
         if (tagValidationResult.isError()) {
             return ValidationResult.error(ConsumptionCoreErrors.requests.invalidAcceptParameters(tagValidationResult.error.message));
         }

--- a/packages/consumption/src/modules/requests/itemProcessors/shareAttribute/ShareAttributeRequestItemProcessor.ts
+++ b/packages/consumption/src/modules/requests/itemProcessors/shareAttribute/ShareAttributeRequestItemProcessor.ts
@@ -160,7 +160,7 @@ export class ShareAttributeRequestItemProcessor extends GenericRequestItemProces
             );
         }
 
-        const tagValidationResult = await this.consumptionController.attributes.validateTags(requestItem.attribute);
+        const tagValidationResult = await this.consumptionController.attributes.validateTagsOfAttribute(requestItem.attribute);
         if (tagValidationResult.isError()) {
             return ValidationResult.error(ConsumptionCoreErrors.requests.invalidRequestItem(tagValidationResult.error.message));
         }
@@ -183,7 +183,7 @@ export class ShareAttributeRequestItemProcessor extends GenericRequestItemProces
     }
 
     public override async canAccept(requestItem: ShareAttributeRequestItem, _params: AcceptRequestItemParametersJSON, _requestInfo: LocalRequestInfo): Promise<ValidationResult> {
-        const tagValidationResult = await this.consumptionController.attributes.validateTags(requestItem.attribute);
+        const tagValidationResult = await this.consumptionController.attributes.validateTagsOfAttribute(requestItem.attribute);
         if (tagValidationResult.isError()) {
             return ValidationResult.error(ConsumptionCoreErrors.requests.invalidRequestItem(tagValidationResult.error.message));
         }

--- a/packages/consumption/test/modules/requests/itemProcessors/proposeAttribute/ProposeAttributeRequestItemProcessor.test.ts
+++ b/packages/consumption/test/modules/requests/itemProcessors/proposeAttribute/ProposeAttributeRequestItemProcessor.test.ts
@@ -874,7 +874,7 @@ describe("ProposeAttributeRequestItemProcessor", function () {
 
         test("returns an error if accepting would accept an Attribute with an invalid tag", async function () {
             const attributesControllerSpy = spy(consumptionController.attributes);
-            when(attributesControllerSpy.validateTags(anything())).thenResolve(ValidationResult.success());
+            when(attributesControllerSpy.validateTagsOfAttribute(anything())).thenResolve(ValidationResult.success());
 
             const existingAttribute = await consumptionController.attributes.createRepositoryAttribute({
                 content: TestObjectFactory.createIdentityAttribute({

--- a/packages/consumption/test/modules/requests/itemProcessors/readAttribute/ReadAttributeRequestItemProcessor.test.ts
+++ b/packages/consumption/test/modules/requests/itemProcessors/readAttribute/ReadAttributeRequestItemProcessor.test.ts
@@ -597,7 +597,7 @@ describe("ReadAttributeRequestItemProcessor", function () {
 
         test("returns an error when the given Attribute has an invalid tag", async function () {
             const attributesControllerSpy = spy(consumptionController.attributes);
-            when(attributesControllerSpy.validateTags(anything())).thenResolve(ValidationResult.success());
+            when(attributesControllerSpy.validateTagsOfAttribute(anything())).thenResolve(ValidationResult.success());
 
             const existingAttribute = await consumptionController.attributes.createRepositoryAttribute({
                 content: TestObjectFactory.createIdentityAttribute({

--- a/packages/consumption/test/modules/requests/itemProcessors/shareAttribute/ShareAttributeRequestItemProcessor.test.ts
+++ b/packages/consumption/test/modules/requests/itemProcessors/shareAttribute/ShareAttributeRequestItemProcessor.test.ts
@@ -1077,7 +1077,7 @@ describe("ShareAttributeRequestItemProcessor", function () {
 
         test("returns an error when sharing an IdentityAttribute with an invalid tag", async function () {
             const attributesControllerSpy = spy(consumptionController.attributes);
-            when(attributesControllerSpy.validateTags(anything())).thenResolve(ValidationResult.success());
+            when(attributesControllerSpy.validateTagsOfAttribute(anything())).thenResolve(ValidationResult.success());
 
             const existingAttribute = await consumptionController.attributes.createRepositoryAttribute({
                 content: TestObjectFactory.createIdentityAttribute({

--- a/packages/runtime/src/useCases/consumption/attributes/CanCreateRepositoryAttribute.ts
+++ b/packages/runtime/src/useCases/consumption/attributes/CanCreateRepositoryAttribute.ts
@@ -1,6 +1,6 @@
 import { Result } from "@js-soft/ts-utils";
 import { AttributesController } from "@nmshd/consumption";
-import { AttributeValues, IdentityAttribute } from "@nmshd/content";
+import { AttributeValues } from "@nmshd/content";
 import { AccountController } from "@nmshd/transport";
 import { Inject } from "@nmshd/typescript-ioc";
 import { RuntimeErrors, SchemaRepository, SchemaValidator, UseCase, ValidationResult } from "../../common";
@@ -59,12 +59,10 @@ export class CanCreateRepositoryAttributeUseCase extends UseCase<CanCreateReposi
             return Result.ok({ isSuccess: false, code: error.code, message: error.message });
         }
 
-        const draftIdentityAttribute = IdentityAttribute.from({
-            owner: this.accountController.identity.address.toString(),
-            ...request.content
-        });
-        const tagValidationResult = await this.attributesController.validateTags(draftIdentityAttribute);
-        if (tagValidationResult.isError()) return Result.ok({ isSuccess: false, code: tagValidationResult.error.code, message: tagValidationResult.error.message });
+        if (request.content.tags && request.content.tags.length > 0) {
+            const tagValidationResult = await this.attributesController.validateTagsForType(request.content.tags, request.content.value["@type"]);
+            if (tagValidationResult.isError()) return Result.ok({ isSuccess: false, code: tagValidationResult.error.code, message: tagValidationResult.error.message });
+        }
 
         return Result.ok({ isSuccess: true });
     }


### PR DESCRIPTION
# Readiness checklist

- [ ] I added/updated tests.
- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

# Description

Using validateTagsForType it's much easier to validate the tags of a File, because it is not necessary to create a draft Attribute.