### PR TITLE
Update the FileDVO to contain `reference.truncated` and `reference.url`

### DIFF
--- a/packages/runtime/src/dataViews/DataViewExpander.ts
+++ b/packages/runtime/src/dataViews/DataViewExpander.ts
@@ -1811,7 +1811,7 @@ export class DataViewExpander {
             filename: file.filename,
             filesize: file.filesize,
             createdBy: await this.expandAddress(file.createdBy),
-            truncatedReference: file.truncatedReference
+            reference: file.reference
         };
     }
 

--- a/packages/runtime/src/dataViews/transport/FileDVO.ts
+++ b/packages/runtime/src/dataViews/transport/FileDVO.ts
@@ -13,5 +13,8 @@ export interface FileDVO extends DataViewObject {
     mimetype: string;
     isOwn: boolean;
     title: string;
-    truncatedReference: string;
+    reference: {
+        truncated: string;
+        url: string;
+    };
 }

--- a/packages/runtime/test/dataViews/requestItems/TransferFileOwnershipRequestItemDVO.test.ts
+++ b/packages/runtime/test/dataViews/requestItems/TransferFileOwnershipRequestItemDVO.test.ts
@@ -109,7 +109,7 @@ describe("TransferFileOwnershipRequestItemDVO", () => {
         expect(requestItemDVO.isDecidable).toBe(false);
         expect(requestItemDVO.fileReference).toBe(truncatedFileReference);
         expect(requestItemDVO.file.type).toBe("FileDVO");
-        expect(requestItemDVO.file.truncatedReference).toBe(truncatedFileReference);
+        expect(requestItemDVO.file.reference.truncated).toBe(truncatedFileReference);
     });
 
     test("check the MessageDVO for the recipient", async () => {
@@ -136,7 +136,7 @@ describe("TransferFileOwnershipRequestItemDVO", () => {
         expect(requestItemDVO.isDecidable).toBe(true);
         expect(requestItemDVO.fileReference).toBe(truncatedFileReference);
         expect(requestItemDVO.file.type).toBe("FileDVO");
-        expect(requestItemDVO.file.truncatedReference).toBe(truncatedFileReference);
+        expect(requestItemDVO.file.reference.truncated).toBe(truncatedFileReference);
     });
 
     test("check the MessageDVO for the recipient after acceptance", async () => {


### PR DESCRIPTION
# Readiness checklist

- [ ] I added/updated tests.
- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

# Description

`truncatedReference` is removed b/c the app doesn't need that value and it seems to be broken anyways.
