### PR TITLE
Allow url references with `nmshd(s)` schema

### DIFF
--- a/packages/app-runtime/src/AppStringProcessor.ts
+++ b/packages/app-runtime/src/AppStringProcessor.ts
@@ -32,7 +32,9 @@ export class AppStringProcessor {
     public async processURL(url: string, account?: LocalAccountDTO): Promise<UserfriendlyResult<void>> {
         url = url.trim();
 
-        if (!url.startsWith("http") && !url.startsWith("nmshd")) return UserfriendlyResult.fail(AppRuntimeErrors.appStringProcessor.wrongURL());
+        const parsed = new URL(url);
+        const allowedProtocols = ["http:", "https:", "nmshd:", "nmshds:"];
+        if (!allowedProtocols.includes(parsed.protocol)) return UserfriendlyResult.fail(AppRuntimeErrors.appStringProcessor.wrongURL());
 
         return await this.processReference(url, account);
     }

--- a/packages/app-runtime/test/runtime/AppStringProcessor.test.ts
+++ b/packages/app-runtime/test/runtime/AppStringProcessor.test.ts
@@ -384,5 +384,21 @@ describe("AppStringProcessor", function () {
 
             expect(runtime4MockUiBridge).showRequestCalled();
         });
+
+        test.each(["nmshd", "nmshds", "http"])("get file using a nmshd url with %s protocol", async function (replacement) {
+            const fileResult = await runtime1Session.transportServices.files.uploadOwnFile({
+                filename: "aFileName",
+                content: new TextEncoder().encode("aFileContent"),
+                mimetype: "aMimetype",
+                expiresAt: CoreDate.utc().add({ minutes: 10 }).toISOString()
+            });
+            const file = fileResult.value;
+
+            const result = await runtime4.stringProcessor.processURL(file.reference.url.replace("https", replacement), runtime4Session.account);
+            expect(result).toBeSuccessful();
+            expect(result.value).toBeUndefined();
+
+            expect(runtime4MockUiBridge).showFileCalled(file.id);
+        });
     });
 });

--- a/packages/core-types/src/references/Reference.ts
+++ b/packages/core-types/src/references/Reference.ts
@@ -153,7 +153,11 @@ export class Reference extends Serializable implements IReference {
         }
 
         if (value.startsWith("nmshd://")) {
-            return this.fromUrl(value.replace("nmshd://", "https://"));
+            return this.fromUrl(value.replace("nmshd://", "http://"));
+        }
+
+        if (value.startsWith("nmshds://")) {
+            return this.fromUrl(value.replace("nmshds://", "https://"));
         }
 
         return this.fromTruncated(value);

--- a/packages/core-types/src/references/Reference.ts
+++ b/packages/core-types/src/references/Reference.ts
@@ -147,8 +147,13 @@ export class Reference extends Serializable implements IReference {
         if (typeof value !== "string") return this.fromAny(value);
 
         if (value.startsWith("http")) return this.fromUrl(value);
+
         if (value.startsWith("nmshd://qr#") || value.startsWith("nmshd://tr#")) {
             return this.fromTruncated(value.substring(11));
+        }
+
+        if (value.startsWith("nmshd://")) {
+            return this.fromUrl(value.replace("nmshd://", "https://"));
         }
 
         return this.fromTruncated(value);

--- a/packages/core-types/test/references/Reference.test.ts
+++ b/packages/core-types/test/references/Reference.test.ts
@@ -90,6 +90,9 @@ describe("Reference", () => {
 
     test.each([
         "https://backbone.example.com/r/ANID1234?app=anAppName#M3xsZXJKeVg4eWRKREVYb3dxMlBNTW50UlhYQTI3d2dISllBX0JqbkZ4NTVZfHw",
+        "https://backbone.example.com/r/ANID1234#M3xsZXJKeVg4eWRKREVYb3dxMlBNTW50UlhYQTI3d2dISllBX0JqbkZ4NTVZfHw",
+        "nmshd://backbone.example.com/r/ANID1234?app=anAppName#M3xsZXJKeVg4eWRKREVYb3dxMlBNTW50UlhYQTI3d2dISllBX0JqbkZ4NTVZfHw",
+        "nmshd://backbone.example.com/r/ANID1234#M3xsZXJKeVg4eWRKREVYb3dxMlBNTW50UlhYQTI3d2dISllBX0JqbkZ4NTVZfHw",
         "QU5JRDEyMzRAaHR0cHM6Ly9iYWNrYm9uZS5leGFtcGxlLmNvbXwzfGxlckp5WDh5ZEpERVhvd3EyUE1NbnRSWFhBMjd3Z0hKWUFfQmpuRng1NVl8fA",
         "nmshd://qr#QU5JRDEyMzRAaHR0cHM6Ly9iYWNrYm9uZS5leGFtcGxlLmNvbXwzfGxlckp5WDh5ZEpERVhvd3EyUE1NbnRSWFhBMjd3Z0hKWUFfQmpuRng1NVl8fA",
         "nmshd://tr#QU5JRDEyMzRAaHR0cHM6Ly9iYWNrYm9uZS5leGFtcGxlLmNvbXwzfGxlckp5WDh5ZEpERVhvd3EyUE1NbnRSWFhBMjd3Z0hKWUFfQmpuRng1NVl8fA"

--- a/packages/core-types/test/references/Reference.test.ts
+++ b/packages/core-types/test/references/Reference.test.ts
@@ -89,16 +89,20 @@ describe("Reference", () => {
     });
 
     test.each([
-        "https://backbone.example.com/r/ANID1234?app=anAppName#M3xsZXJKeVg4eWRKREVYb3dxMlBNTW50UlhYQTI3d2dISllBX0JqbkZ4NTVZfHw",
-        "https://backbone.example.com/r/ANID1234#M3xsZXJKeVg4eWRKREVYb3dxMlBNTW50UlhYQTI3d2dISllBX0JqbkZ4NTVZfHw",
-        "nmshd://backbone.example.com/r/ANID1234?app=anAppName#M3xsZXJKeVg4eWRKREVYb3dxMlBNTW50UlhYQTI3d2dISllBX0JqbkZ4NTVZfHw",
-        "nmshd://backbone.example.com/r/ANID1234#M3xsZXJKeVg4eWRKREVYb3dxMlBNTW50UlhYQTI3d2dISllBX0JqbkZ4NTVZfHw",
-        "QU5JRDEyMzRAaHR0cHM6Ly9iYWNrYm9uZS5leGFtcGxlLmNvbXwzfGxlckp5WDh5ZEpERVhvd3EyUE1NbnRSWFhBMjd3Z0hKWUFfQmpuRng1NVl8fA",
-        "nmshd://qr#QU5JRDEyMzRAaHR0cHM6Ly9iYWNrYm9uZS5leGFtcGxlLmNvbXwzfGxlckp5WDh5ZEpERVhvd3EyUE1NbnRSWFhBMjd3Z0hKWUFfQmpuRng1NVl8fA",
-        "nmshd://tr#QU5JRDEyMzRAaHR0cHM6Ly9iYWNrYm9uZS5leGFtcGxlLmNvbXwzfGxlckp5WDh5ZEpERVhvd3EyUE1NbnRSWFhBMjd3Z0hKWUFfQmpuRng1NVl8fA"
-    ])("Reference#from called with %s", (value) => {
-        const reference = Reference.from(value);
+        ["https://backbone.example.com/r/ANID1234?app=anAppName#M3xsZXJKeVg4eWRKREVYb3dxMlBNTW50UlhYQTI3d2dISllBX0JqbkZ4NTVZfHw", "https://backbone.example.com"],
+        ["https://backbone.example.com/r/ANID1234#M3xsZXJKeVg4eWRKREVYb3dxMlBNTW50UlhYQTI3d2dISllBX0JqbkZ4NTVZfHw", "https://backbone.example.com"],
+        ["nmshd://backbone.example.com/r/ANID1234?app=anAppName#M3xsZXJKeVg4eWRKREVYb3dxMlBNTW50UlhYQTI3d2dISllBX0JqbkZ4NTVZfHw", "http://backbone.example.com"],
+        ["nmshd://backbone.example.com/r/ANID1234#M3xsZXJKeVg4eWRKREVYb3dxMlBNTW50UlhYQTI3d2dISllBX0JqbkZ4NTVZfHw", "http://backbone.example.com"],
+        ["nmshds://backbone.example.com/r/ANID1234?app=anAppName#M3xsZXJKeVg4eWRKREVYb3dxMlBNTW50UlhYQTI3d2dISllBX0JqbkZ4NTVZfHw", "https://backbone.example.com"],
+        ["nmshds://backbone.example.com/r/ANID1234#M3xsZXJKeVg4eWRKREVYb3dxMlBNTW50UlhYQTI3d2dISllBX0JqbkZ4NTVZfHw", "https://backbone.example.com"],
+        ["QU5JRDEyMzRAaHR0cHM6Ly9iYWNrYm9uZS5leGFtcGxlLmNvbXwzfGxlckp5WDh5ZEpERVhvd3EyUE1NbnRSWFhBMjd3Z0hKWUFfQmpuRng1NVl8fA", "https://backbone.example.com"],
+        ["nmshd://qr#QU5JRDEyMzRAaHR0cHM6Ly9iYWNrYm9uZS5leGFtcGxlLmNvbXwzfGxlckp5WDh5ZEpERVhvd3EyUE1NbnRSWFhBMjd3Z0hKWUFfQmpuRng1NVl8fA", "https://backbone.example.com"],
+        ["nmshd://tr#QU5JRDEyMzRAaHR0cHM6Ly9iYWNrYm9uZS5leGFtcGxlLmNvbXwzfGxlckp5WDh5ZEpERVhvd3EyUE1NbnRSWFhBMjd3Z0hKWUFfQmpuRng1NVl8fA", "https://backbone.example.com"]
+    ])("Reference#from called with %i and baseurl is %i", (referenceString, baseUrl) => {
+        const reference = Reference.from(referenceString);
 
         expect(reference).toBeInstanceOf(Reference);
+        expect(reference.id.toString()).toBe("ANID1234");
+        expect(reference.backboneBaseUrl).toBe(baseUrl);
     });
 });


### PR DESCRIPTION
# Readiness checklist

- [ ] I added/updated tests.
- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

# Description

To route from the document hosted at `https://backbone.example.com/r/ID#12345` to the app we need to accept `nmshds://backbone.example.com/r/ID#12345` to be processed from the apps. Each app will only listen on their personal backbone.
