### PR TITLE
`processDeviceOnboardingReference` is throwing when getting an invalid reference

### DIFF
--- a/packages/app-runtime/src/AppStringProcessor.ts
+++ b/packages/app-runtime/src/AppStringProcessor.ts
@@ -158,6 +158,7 @@ export class AppStringProcessor {
         } catch (_) {
             return UserfriendlyResult.fail(AppRuntimeErrors.appStringProcessor.invalidReference());
         }
+
         if (!reference.id.toString().startsWith("TOK")) return UserfriendlyResult.fail(AppRuntimeErrors.appStringProcessor.noDeviceOnboardingCode());
 
         const tokenResultHolder = reference.passwordProtection

--- a/packages/app-runtime/src/AppStringProcessor.ts
+++ b/packages/app-runtime/src/AppStringProcessor.ts
@@ -151,7 +151,13 @@ export class AppStringProcessor {
     public async processDeviceOnboardingReference(url: string): Promise<UserfriendlyResult<void>> {
         url = url.trim();
 
-        const reference = Reference.from(url);
+        let reference: Reference;
+
+        try {
+            reference = Reference.from(url);
+        } catch (_) {
+            return UserfriendlyResult.fail(AppRuntimeErrors.appStringProcessor.invalidReference());
+        }
         if (!reference.id.toString().startsWith("TOK")) return UserfriendlyResult.fail(AppRuntimeErrors.appStringProcessor.noDeviceOnboardingCode());
 
         const tokenResultHolder = reference.passwordProtection


### PR DESCRIPTION
# Readiness checklist

- [ ] I added/updated tests.
- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

<!-- # Description -->
