### PR TITLE
Add `wasAutomaticallyDecided` query parameter to use case for querying incoming Requests

### DIFF
--- a/packages/runtime/src/useCases/common/Schemas.ts
+++ b/packages/runtime/src/useCases/common/Schemas.ts
@@ -11760,6 +11760,9 @@ export const GetIncomingRequestsRequest: any = {
                         }
                     ]
                 },
+                "wasAutomaticallyDecided": {
+                    "type": "string"
+                },
                 "content.expiresAt": {
                     "anyOf": [
                         {

--- a/packages/runtime/src/useCases/consumption/requests/GetIncomingRequests.ts
+++ b/packages/runtime/src/useCases/consumption/requests/GetIncomingRequests.ts
@@ -18,6 +18,7 @@ export interface GetIncomingRequestsRequestQuery {
     peer?: string | string[];
     createdAt?: string | string[];
     status?: string | string[];
+    wasAutomaticallyDecided?: string;
     "content.expiresAt"?: string | string[];
     "content.items.@type"?: string | string[];
     "source.type"?: string | string[];
@@ -44,6 +45,9 @@ export class GetIncomingRequestsUseCase extends UseCase<GetIncomingRequestsReque
 
             // status
             [nameof<LocalRequestDTO>((x) => x.status)]: true,
+
+            // wasAutomaticallyDecided
+            [nameof<LocalRequestDTO>((x) => x.wasAutomaticallyDecided)]: true,
 
             // content.expiresAt
             [`${nameof<LocalRequestDTO>((x) => x.content)}.${nameof<RequestJSON>((x) => x.expiresAt)}`]: true,
@@ -92,6 +96,9 @@ export class GetIncomingRequestsUseCase extends UseCase<GetIncomingRequestsReque
 
             // status
             [nameof<LocalRequestDTO>((x) => x.status)]: nameof<LocalRequest>((x) => x.status),
+
+            // wasAutomaticallyDecided
+            [nameof<LocalRequestDTO>((x) => x.wasAutomaticallyDecided)]: nameof<LocalRequest>((x) => x.wasAutomaticallyDecided),
 
             // content.expiresAt
             [`${nameof<LocalRequestDTO>((x) => x.content)}.${nameof<RequestJSON>((x) => x.expiresAt)}`]: `${nameof<LocalRequest>((x) => x.content)}.${nameof<RequestJSON>(


### PR DESCRIPTION
# Readiness checklist

- [ ] I added/updated tests.
- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

 # Description

As the property `wasAutomaticallyDecided` was added to the LocalRequest in PR https://github.com/nmshd/runtime/pull/568, it can be added as query parameter to the use case for querying incoming Requests as well.