### PR TITLE
Unused `cannotSetWasAutomaticallyDecided` error code

### DIFF
--- a/packages/consumption/src/consumption/ConsumptionCoreErrors.ts
+++ b/packages/consumption/src/consumption/ConsumptionCoreErrors.ts
@@ -354,13 +354,6 @@ class Requests {
         );
     }
 
-    public cannotSetWasAutomaticallyDecided(id: string, status: string) {
-        return new CoreError(
-            "error.consumption.requests.cannotSetWasAutomaticallyDecided",
-            `The incoming Request '${id}' has status '${status}', but it must have status 'Decided' to set wasAutomaticallyDecided.`
-        );
-    }
-
     private static readonly _decideValidation = class {
         public invalidNumberOfItems(message: string) {
             return new ApplicationError("error.consumption.requests.decide.validation.invalidNumberOfItems", message);


### PR DESCRIPTION
# Readiness checklist

- [ ] I added/updated tests.
- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

# Description

The `error.consumption.requests.cannotSetWasAutomaticallyDecided` error code was needed in the first version of Runtime PR https://github.com/nmshd/runtime/pull/568. However, in the final merged version, it wasn't needed anymore which is why it can be removed now.
