### PR TITLE
Use syncUntilHasFile to ensure external events are received

### DIFF
--- a/packages/transport/test/testHelpers/TestUtil.ts
+++ b/packages/transport/test/testHelpers/TestUtil.ts
@@ -533,6 +533,14 @@ export class TestUtil {
         return await TestUtil.syncUntilHas(accountController, id, "messages");
     }
 
+    public static async syncUntilHasFiles(accountController: AccountController, expectedNumberOfFiles = 1): Promise<File[]> {
+        return await TestUtil.syncUntilHasMany(accountController, "files", expectedNumberOfFiles);
+    }
+
+    public static async syncUntilHasFile(accountController: AccountController, id: CoreId): Promise<File[]> {
+        return await TestUtil.syncUntilHas(accountController, id, "files");
+    }
+
     public static async syncUntilHasError(accountController: AccountController): Promise<any> {
         try {
             await TestUtil.syncUntilHasMessages(accountController, 100);


### PR DESCRIPTION
# Readiness checklist

- [x] I added/updated tests.
- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

# Description

This makes the tests more robust.
