### PR TITLE
NMSHD_TEST_ADMIN_API_KEY is not defined in dev readme

### DIFF
--- a/README_dev.md
+++ b/README_dev.md
@@ -55,9 +55,10 @@ npm run start:backbone
 Set the following environment variables:
 
 - `NMSHD_TEST_BASEURL` to `http://localhost:8090`
-- `NMSHD_TEST_BASEURL_ADMIN_API` to `http://localhost:8091`
 - `NMSHD_TEST_CLIENTID` to `test`
 - `NMSHD_TEST_CLIENTSECRET` to `test`
+- `NMSHD_TEST_BASEURL_ADMIN_API` to `http://localhost:8091`
+- `NMSHD_TEST_ADMIN_API_KEY` to `test`
 
 > We recommend to persist these variables for example in your `.bashrc` / `.zshrc` or in the Windows environment variables.
 


### PR DESCRIPTION
# Readiness checklist

- [ ] I added/updated tests.
- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

<!-- # Description -->
