### PR TITLE
Endless loop when updating request expiry

### DIFF
--- a/packages/consumption/src/modules/requests/incoming/IncomingRequestsController.ts
+++ b/packages/consumption/src/modules/requests/incoming/IncomingRequestsController.ts
@@ -433,7 +433,7 @@ export class IncomingRequestsController extends ConsumptionBaseController {
             isOwn: false
         });
 
-        const requestPromises = requestDocs.map((r) => this.updateRequestExpiry(LocalRequest.from(r)));
+        const requestPromises = requestDocs.map((r) => this.updateRequestExpiry(r, LocalRequest.from(r)));
         return await Promise.all(requestPromises);
     }
 
@@ -443,7 +443,7 @@ export class IncomingRequestsController extends ConsumptionBaseController {
 
         const localRequest = LocalRequest.from(requestDoc);
 
-        return await this.updateRequestExpiry(localRequest);
+        return await this.updateRequestExpiry(requestDoc, localRequest);
     }
 
     private async getOrThrow(id: CoreId | string) {
@@ -483,12 +483,12 @@ export class IncomingRequestsController extends ConsumptionBaseController {
         }
     }
 
-    private async updateRequestExpiry(request: LocalRequest) {
+    private async updateRequestExpiry(requestDoc: any, request: LocalRequest) {
         const oldStatus = request.status;
 
         const statusUpdated = request.updateStatusBasedOnExpiration();
         if (statusUpdated) {
-            await this.update(request);
+            await this.localRequests.update(requestDoc, request);
 
             this.eventBus.publish(new IncomingRequestStatusChangedEvent(this.identity.address.toString(), { request, oldStatus, newStatus: request.status }));
         }

--- a/packages/consumption/src/modules/requests/outgoing/OutgoingRequestsController.ts
+++ b/packages/consumption/src/modules/requests/outgoing/OutgoingRequestsController.ts
@@ -396,7 +396,7 @@ export class OutgoingRequestsController extends ConsumptionBaseController {
             isOwn: true
         });
 
-        const requestPromises = requestDocs.map((r) => this.updateRequestExpiry(LocalRequest.from(r)));
+        const requestPromises = requestDocs.map((r) => this.updateRequestExpiry(r, LocalRequest.from(r)));
         return await Promise.all(requestPromises);
     }
 
@@ -412,7 +412,7 @@ export class OutgoingRequestsController extends ConsumptionBaseController {
         if (!requestDoc) return;
 
         const localRequest = LocalRequest.from(requestDoc);
-        return await this.updateRequestExpiry(localRequest);
+        return await this.updateRequestExpiry(requestDoc, localRequest);
     }
 
     private async getOrThrow(id: CoreId) {
@@ -437,12 +437,12 @@ export class OutgoingRequestsController extends ConsumptionBaseController {
         }
     }
 
-    private async updateRequestExpiry(request: LocalRequest) {
+    private async updateRequestExpiry(requestDoc: any, request: LocalRequest) {
         const oldStatus = request.status;
 
         const statusUpdated = request.updateStatusBasedOnExpiration();
         if (statusUpdated) {
-            await this.update(request);
+            await this.localRequests.update(requestDoc, request);
 
             this.eventBus.publish(new OutgoingRequestStatusChangedEvent(this.identity.address.toString(), { request: request, oldStatus, newStatus: request.status }));
         }


### PR DESCRIPTION
# Readiness checklist

- [ ] I added/updated tests.
- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

# Description

Before #612 there could be multiple requests with the same ID. This can cause an endless loop when those requests are queried. With this fix we stop this endless loop.