### PR TITLE
Should decrypt a message on a terminated relationship test is doing nothing for the recipient

### DIFF
--- a/packages/transport/test/modules/messages/MessageController.test.ts
+++ b/packages/transport/test/modules/messages/MessageController.test.ts
@@ -272,7 +272,13 @@ describe("MessageController", function () {
     });
 
     describe("Sending Messages for terminated Relationships", function () {
+        let messageExchangedBeforeTermination: Message;
+
         beforeAll(async function () {
+            const message = await TestUtil.sendMessage(sender, recipient);
+            await TestUtil.syncUntilHasMessage(recipient, message.id);
+            messageExchangedBeforeTermination = message;
+
             await TestUtil.terminateRelationship(sender, recipient);
         });
 

--- a/packages/transport/test/modules/messages/MessageController.test.ts
+++ b/packages/transport/test/modules/messages/MessageController.test.ts
@@ -287,9 +287,14 @@ describe("MessageController", function () {
         });
 
         test("should decrypt a Message on a terminated Relationship", async function () {
-            const messageId = (await TestUtil.sendMessage(sender, recipient)).id;
-            await expect(sender.messages.fetchCaches([messageId])).resolves.not.toThrow();
-            await expect(recipient.messages.fetchCaches([messageId])).resolves.not.toThrow();
+            const messageId = messageExchangedBeforeTermination.id;
+
+            const result = await sender.messages.fetchCaches([messageId]);
+            // fetchCaches is just returning an empty array if the message is not found
+            expect(result).toHaveLength(1);
+
+            const recipientResult = await recipient.messages.fetchCaches([messageId]);
+            expect(recipientResult).toHaveLength(1);
         });
 
         test("should be able to receive a Message sent on a terminated Relationship after the Relationship was reactivated", async function () {


### PR DESCRIPTION
# Readiness checklist

- [ ] I added/updated tests.
- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

# Description

That test was nonsense. The message never popped of at recipient side and this test logged a strange `Message '....' not found in local database and the cache fetching was therefore skipped. This should not happen and might be a bug in the application logic.` log message in every test run. Echanging the message before termination solves this as we actually CAN test this for the recipient.