### PR TITLE
Flaky runtime test

### DIFF
--- a/packages/runtime/src/useCases/transport/files/GetFiles.ts
+++ b/packages/runtime/src/useCases/transport/files/GetFiles.ts
@@ -79,6 +79,9 @@ export class GetFilesUseCase extends UseCase<GetFilesRequest, FileDTO[]> {
                     allowedTags.push(tagQuery);
                 }
                 query["$or"] = allowedTags;
+            },
+            [nameof<FileDTO>((c) => c.ownershipToken)]: (query: any, input: string | string[]) => {
+                query[`${nameof<File>((f) => f.ownershipToken)}`] = input;
             }
         }
     });

--- a/packages/runtime/test/lib/QueryParamConditions.ts
+++ b/packages/runtime/test/lib/QueryParamConditions.ts
@@ -116,7 +116,7 @@ export class QueryParamConditions<TQuery extends PartialRecord<keyof TQuery, str
 
         this._conditions.push({
             key: key,
-            value: positiveValue.replace(/....$/, "XXXX"),
+            value: positiveValue.replace(/....$/, "XXXX").replace(/^..../, "XXXX"),
             expectedResult: false
         });
 

--- a/packages/runtime/test/lib/QueryParamConditions.ts
+++ b/packages/runtime/test/lib/QueryParamConditions.ts
@@ -116,7 +116,7 @@ export class QueryParamConditions<TQuery extends PartialRecord<keyof TQuery, str
 
         this._conditions.push({
             key: key,
-            value: positiveValue.replace(/....$/, "XXXX").replace(/^..../, "XXXX"),
+            value: positiveValue.replace(/..$/, "XX").replace(/^../, "XX"),
             expectedResult: false
         });
 


### PR DESCRIPTION
# Readiness checklist

- [ ] I added/updated tests.
- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

# Description

I finally (hopefully :D) discovered why that one files test always fails.

It looks like the ownership token logged here: `Positive match failed for key "ownershipToken" and value "^M]~g|9@mr*kcVFC0w=a".` Translates to a regex because it starts with `^`. It's definitely no real regex, but it's treated like a regex in our lib.

Therefore I disabled the value parsing for this value. This means that it's not possible to negate the ownershipToken for example, but that should be ok.