### PR TITLE
Use nodejs http and https proxy support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
                 "@js-soft/eslint-config-ts": "^2.0.3",
                 "@js-soft/license-check": "^1.0.9",
                 "@types/jest": "^30.0.0",
-                "@types/node": "^22.17.1",
+                "@types/node": "^24.3.0",
                 "enhanced-publish": "^1.1.4",
                 "eslint": "^9.33.0",
                 "jest": "^30.0.5",
@@ -2500,13 +2500,13 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "22.17.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.17.1.tgz",
-            "integrity": "sha512-y3tBaz+rjspDTylNjAX37jEC3TETEFGNJL6uQDxwF9/8GLLIjW1rvVHlynyuUKMnMr1Roq8jOv3vkopBjC4/VA==",
+            "version": "24.3.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
+            "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "undici-types": "~6.21.0"
+                "undici-types": "~7.10.0"
             }
         },
         "node_modules/@types/qs": {
@@ -10657,9 +10657,9 @@
             }
         },
         "node_modules/undici-types": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+            "version": "7.10.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+            "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
             "dev": true,
             "license": "MIT"
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -3247,6 +3247,7 @@
         },
         "node_modules/agent-base": {
             "version": "7.1.3",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 14"
@@ -4462,6 +4463,7 @@
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
             "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ms": "^2.1.3"
@@ -6099,6 +6101,7 @@
         },
         "node_modules/https-proxy-agent": {
             "version": "7.0.6",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "agent-base": "^7.1.2",
@@ -7951,6 +7954,7 @@
         },
         "node_modules/ms": {
             "version": "2.1.3",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/nan": {
@@ -11221,7 +11225,6 @@
                 "axios": "^1.11.0",
                 "fast-json-patch": "^3.1.1",
                 "form-data": "^4.0.4",
-                "https-proxy-agent": "^7.0.6",
                 "json-stringify-safe": "^5.0.1",
                 "lodash": "^4.17.21",
                 "luxon": "^3.7.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "@js-soft/eslint-config-ts": "^2.0.3",
         "@js-soft/license-check": "^1.0.9",
         "@types/jest": "^30.0.0",
-        "@types/node": "^22.17.1",
+        "@types/node": "^24.3.0",
         "enhanced-publish": "^1.1.4",
         "eslint": "^9.33.0",
         "jest": "^30.0.5",

--- a/packages/transport/package.json
+++ b/packages/transport/package.json
@@ -75,7 +75,6 @@
         "axios": "^1.11.0",
         "fast-json-patch": "^3.1.1",
         "form-data": "^4.0.4",
-        "https-proxy-agent": "^7.0.6",
         "json-stringify-safe": "^5.0.1",
         "lodash": "^4.17.21",
         "luxon": "^3.7.1",

--- a/packages/transport/src/core/backbone/RESTClient.ts
+++ b/packages/transport/src/core/backbone/RESTClient.ts
@@ -84,24 +84,13 @@ export class RESTClient {
 
         const resultingRequestConfig = _.defaultsDeep(defaults, requestConfig);
 
-        if (typeof window === "undefined" && (process.env.https_proxy ?? process.env.HTTPS_PROXY)) {
-            try {
-                const httpsProxy = (process.env.https_proxy ?? process.env.HTTPS_PROXY)!;
-                // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/naming-convention
-                const HttpsProxyAgent = require("https-proxy-agent").HttpsProxyAgent;
-                resultingRequestConfig.httpsAgent = new HttpsProxyAgent(httpsProxy, this.config.httpsAgentOptions);
-            } catch (_) {
-                // ignore
-            }
-        } else {
-            try {
-                // eslint-disable-next-line @typescript-eslint/no-require-imports
-                const httpsAgent = require("https")?.Agent;
+        try {
+            // eslint-disable-next-line @typescript-eslint/no-require-imports
+            const httpsAgent = require("https")?.Agent;
 
-                if (httpsAgent) resultingRequestConfig.httpsAgent = new httpsAgent(this.config.httpsAgentOptions);
-            } catch (_) {
-                // ignore
-            }
+            if (httpsAgent) resultingRequestConfig.httpsAgent = new httpsAgent(this.config.httpsAgentOptions);
+        } catch (_) {
+            // ignore
         }
 
         try {

--- a/packages/transport/src/core/backbone/RESTClient.ts
+++ b/packages/transport/src/core/backbone/RESTClient.ts
@@ -88,7 +88,7 @@ export class RESTClient {
             // eslint-disable-next-line @typescript-eslint/no-require-imports
             const httpsAgent = require("https")?.Agent;
 
-            if (httpsAgent) resultingRequestConfig.httpsAgent = new httpsAgent(this.config.httpsAgentOptions);
+            if (httpsAgent) resultingRequestConfig.httpsAgent = new httpsAgent({ ...this.config.httpsAgentOptions, proxyEnv: process.env } satisfies HTTPSAgentOptions);
         } catch (_) {
             // ignore
         }
@@ -97,7 +97,7 @@ export class RESTClient {
             // eslint-disable-next-line @typescript-eslint/no-require-imports
             const agent = require("http")?.Agent;
 
-            if (agent) resultingRequestConfig.httpAgent = new agent(this.config.httpAgentOptions);
+            if (agent) resultingRequestConfig.httpAgent = new agent({ ...this.config.httpAgentOptions, proxyEnv: process.env } satisfies HTTPSAgentOptions);
         } catch (_) {
             // ignore
         }


### PR DESCRIPTION
# Readiness checklist

- [ ] I added/updated tests.
- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [ ] I self-reviewed the PR.

# Description

https://nodejs.org/api/http.html#built-in-proxy-support

Can currently not be merged as `@types/node` doesn't support the proxy members.