### PR TITLE
Add the possibility to choose a device name during account creation and onboarding

### DIFF
--- a/packages/app-runtime/src/multiAccount/AccountServices.ts
+++ b/packages/app-runtime/src/multiAccount/AccountServices.ts
@@ -7,14 +7,14 @@ import { LocalAccountMapper } from "./data/LocalAccountMapper";
 export class AccountServices {
     public constructor(protected readonly multiAccountController: MultiAccountController) {}
 
-    public async createAccount(name: string): Promise<LocalAccountDTO> {
-        const [localAccount] = await this.multiAccountController.createAccount(name);
+    public async createAccount(name: string, deviceName?: string): Promise<LocalAccountDTO> {
+        const [localAccount] = await this.multiAccountController.createAccount(name, deviceName);
         return LocalAccountMapper.toLocalAccountDTO(localAccount);
     }
 
-    public async onboardAccount(onboardingInfo: DeviceOnboardingInfoDTO, name?: string): Promise<LocalAccountDTO> {
+    public async onboardAccount(onboardingInfo: DeviceOnboardingInfoDTO, name?: string, deviceName?: string): Promise<LocalAccountDTO> {
         const sharedSecret = DeviceMapper.toDeviceSharedSecret(onboardingInfo);
-        const [localAccount] = await this.multiAccountController.onboardDevice(sharedSecret, name);
+        const [localAccount] = await this.multiAccountController.onboardDevice(sharedSecret, name, deviceName);
         return LocalAccountMapper.toLocalAccountDTO(localAccount);
     }
 

--- a/packages/app-runtime/src/multiAccount/MultiAccountController.ts
+++ b/packages/app-runtime/src/multiAccount/MultiAccountController.ts
@@ -161,7 +161,7 @@ export class MultiAccountController {
         }
     }
 
-    public async onboardDevice(deviceSharedSecret: DeviceSharedSecret, name?: string): Promise<[LocalAccount, AccountController]> {
+    public async onboardDevice(deviceSharedSecret: DeviceSharedSecret, name?: string, deviceName?: string): Promise<[LocalAccount, AccountController]> {
         const existingAccounts = await this._localAccounts.find({ address: deviceSharedSecret.identity.address.toString() });
         if (existingAccounts.length > 0 && !this.config.allowMultipleAccountsWithSameAddress) {
             throw new CoreError(
@@ -190,7 +190,7 @@ export class MultiAccountController {
 
         this._log.trace(`Initializing AccountController for local account ${id}...`);
         const accountController = new AccountController(this.transport, db, this.transport.config);
-        await accountController.init(deviceSharedSecret);
+        await accountController.init(deviceSharedSecret, deviceName);
         this._log.trace(`AccountController for local account ${id} initialized.`);
 
         this._openAccounts[id.toString()] = accountController;
@@ -212,7 +212,7 @@ export class MultiAccountController {
         return [updatedLocalAccount, accountController];
     }
 
-    public async createAccount(name: string): Promise<[LocalAccount, AccountController]> {
+    public async createAccount(name: string, deviceName?: string): Promise<[LocalAccount, AccountController]> {
         const id = await CoreIdHelper.notPrefixed.generate();
 
         let localAccount = LocalAccount.from({
@@ -230,7 +230,7 @@ export class MultiAccountController {
 
         this._log.trace(`Initializing AccountController for local account ${id}...`);
         const accountController = new AccountController(this.transport, db, this.transport.config);
-        await accountController.init();
+        await accountController.init(undefined, deviceName);
         this._log.trace(`AccountController for local account ${id} initialized.`);
 
         this._openAccounts[id.toString()] = accountController;

--- a/packages/app-runtime/test/runtime/Startup.test.ts
+++ b/packages/app-runtime/test/runtime/Startup.test.ts
@@ -53,7 +53,7 @@ describe("Runtime Startup", function () {
     });
 
     test("should create an account", async function () {
-        localAccount = await runtime.accountServices.createAccount("Profil 1");
+        localAccount = await runtime.accountServices.createAccount("aProfileName", "aDeviceName");
 
         expect(localAccount).toBeDefined();
     });
@@ -62,6 +62,17 @@ describe("Runtime Startup", function () {
         const selectedAccount = await runtime.selectAccount(localAccount.id);
         expect(selectedAccount).toBeDefined();
         expect(selectedAccount.account.id.toString()).toBe(localAccount.id.toString());
+    });
+
+    test("should have set the device name", async function () {
+        const selectedAccount = await runtime.selectAccount(localAccount.id);
+        expect(selectedAccount).toBeDefined();
+
+        const devicesResult = await selectedAccount.transportServices.devices.getDevices();
+
+        const devices = devicesResult.value;
+        expect(devices).toHaveLength(1);
+        expect(devices[0].name).toBe("aDeviceName");
     });
 });
 

--- a/packages/runtime-types/src/transport/DeviceDTO.ts
+++ b/packages/runtime-types/src/transport/DeviceDTO.ts
@@ -3,7 +3,7 @@ export interface DeviceDTO {
     isAdmin: boolean;
     publicKey?: string;
     certificate?: string;
-    name: string;
+    name?: string;
     description?: string;
     createdAt: string;
     createdByDevice: string;

--- a/packages/transport/src/modules/accounts/AccountController.ts
+++ b/packages/transport/src/modules/accounts/AccountController.ts
@@ -121,7 +121,7 @@ export class AccountController {
     }
 
     @log()
-    public async init(deviceSharedSecret?: DeviceSharedSecret): Promise<AccountController> {
+    public async init(deviceSharedSecret?: DeviceSharedSecret, deviceName?: string): Promise<AccountController> {
         this.info = await this.db.getMap("AccountInfo");
         this.unpushedDatawalletModifications = await this.db.getCollection(DbCollectionName.UnpushedDatawalletModifications);
 
@@ -146,14 +146,14 @@ export class AccountController {
 
                 // Identity creation
                 this._log.trace("No account information found. Creating new account...");
-                const result = await this.createIdentityAndDevice();
+                const result = await this.createIdentityAndDevice(deviceName);
 
                 identityCreated = true;
                 device = result.device;
                 this.deviceAuthClient = new DeviceAuthClient(this.config, this.authenticator, this.transport.correlator);
             } else {
                 // Device Onboarding
-                device = await this.onboardDevice(deviceSharedSecret);
+                device = await this.onboardDevice(deviceSharedSecret, deviceName);
                 deviceUpdated = true;
             }
         } else if (!deviceSharedSecret && availableIdentityDoc && availableDeviceDoc) {
@@ -265,7 +265,7 @@ export class AccountController {
     }
 
     @log()
-    private async createIdentityAndDevice(): Promise<{ identity: Identity; device: Device }> {
+    private async createIdentityAndDevice(deviceName?: string): Promise<{ identity: Identity; device: Device }> {
         const [identityKeypair, devicePwdD1, deviceKeypair, privBaseShared, privBaseDevice] = await Promise.all([
             // Generate identity keypair
             CoreCrypto.generateSignatureKeypair(),
@@ -328,7 +328,7 @@ export class AccountController {
             createdAt: CoreDate.from(createdIdentity.createdAt),
             createdByDevice: deviceId,
             id: deviceId,
-            name: "Device 1",
+            name: deviceName,
             lastLoginAt: CoreDate.utc(),
             operatingSystem: deviceInfo.operatingSystem,
             publicKey: deviceKeypair.publicKey,
@@ -384,7 +384,7 @@ export class AccountController {
         return { identity, device };
     }
 
-    public async onboardDevice(deviceSharedSecret: DeviceSharedSecret): Promise<Device> {
+    public async onboardDevice(deviceSharedSecret: DeviceSharedSecret, deviceName?: string): Promise<Device> {
         this._log.trace("Onboarding device for existing identity...");
         const [devicePwdDn, deviceKeypair, deviceInfo, privBaseDevice] = await Promise.all([
             // Generate strong device password
@@ -398,7 +398,7 @@ export class AccountController {
 
         const device = Device.from({
             id: deviceSharedSecret.id,
-            name: deviceSharedSecret.name ?? "",
+            name: deviceName ?? deviceSharedSecret.name,
             description: deviceSharedSecret.description,
             lastLoginAt: CoreDate.utc(),
             createdAt: deviceSharedSecret.createdAt,

--- a/packages/transport/src/modules/devices/DeviceController.ts
+++ b/packages/transport/src/modules/devices/DeviceController.ts
@@ -25,7 +25,7 @@ export class DeviceController extends TransportController {
         return this.device.certificate;
     }
 
-    public get name(): string {
+    public get name(): string | undefined {
         return this.device.name;
     }
 

--- a/packages/transport/src/modules/devices/DevicesController.ts
+++ b/packages/transport/src/modules/devices/DevicesController.ts
@@ -41,11 +41,6 @@ export class DevicesController extends TransportController {
     }
 
     public async sendDevice(parameters: ISendDeviceParameters): Promise<Device> {
-        if (!parameters.name) {
-            const devices = await this.parent.devices.list();
-            parameters.name = `Device ${devices.length + 1}`;
-        }
-
         const parsedParams = SendDeviceParameters.from(parameters);
         const device = await this.createDevice(parsedParams);
 

--- a/packages/transport/src/modules/devices/local/Device.ts
+++ b/packages/transport/src/modules/devices/local/Device.ts
@@ -21,7 +21,7 @@ export interface IDevice extends ICoreSynchronizable {
     isAdmin?: boolean;
     publicKey?: ICryptoSignaturePublicKey;
     certificate?: string;
-    name: string;
+    name?: string;
     description?: string;
     createdAt: CoreDate;
     createdByDevice: CoreId;
@@ -65,9 +65,9 @@ export class Device extends CoreSynchronizable implements IDevice {
     @serialize()
     public certificate?: string;
 
-    @validate()
+    @validate({ nullable: true })
     @serialize()
-    public name: string;
+    public name?: string;
 
     @validate({ nullable: true })
     @serialize()

--- a/packages/transport/src/modules/devices/local/SendDeviceParameters.ts
+++ b/packages/transport/src/modules/devices/local/SendDeviceParameters.ts
@@ -9,9 +9,9 @@ export interface ISendDeviceParameters extends ISerializable {
 
 @type("SendDeviceParameters")
 export class SendDeviceParameters extends Serializable implements ISendDeviceParameters {
-    @validate()
+    @validate({ nullable: true })
     @serialize()
-    public name: string;
+    public name?: string;
 
     @validate({ nullable: true })
     @serialize()


### PR DESCRIPTION
# Readiness checklist

- [ ] I added/updated tests.
- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

# Description

There are multiple issues with the current approach which are fixed in this PR:

- Device is currently not translated
- We want to store `Manufacturer Product` as the device name, this should be done immediately at account creation / onboarding, to not have the value `Device <number>` shown to the user
