### PR TITLE
The reference can not be parsed by old runtime versions because of tailing '&'

### DIFF
--- a/packages/core-types/src/SharedPasswordProtection.ts
+++ b/packages/core-types/src/SharedPasswordProtection.ts
@@ -62,6 +62,6 @@ export class SharedPasswordProtection extends Serializable implements ISharedPas
 
         if (this.passwordLocationIndicator === undefined && this.password === undefined) return base;
 
-        return `${base}&${this.passwordLocationIndicator ?? ""}&${this.password ?? ""}`;
+        return `${base}&${this.passwordLocationIndicator ?? ""}${this.password ? `&${this.password}` : ""}`;
     }
 }

--- a/packages/core-types/test/references/Reference.test.ts
+++ b/packages/core-types/test/references/Reference.test.ts
@@ -70,6 +70,26 @@ describe("Reference", () => {
         );
     });
 
+    test("toUrl without a cleartext password but with a passwordLocationIndicator in the passwordProtection reference fields used", () => {
+        const reference = Reference.from({
+            id: CoreId.from("ANID1234"),
+            backboneBaseUrl: "https://backbone.example.com",
+            key: CryptoSecretKey.from({
+                secretKey: CoreBuffer.from("lerJyX8ydJDEXowq2PMMntRXXA27wgHJYA_BjnFx55Y"),
+                algorithm: CryptoEncryptionAlgorithm.XCHACHA20_POLY1305
+            }),
+            passwordProtection: SharedPasswordProtection.from({
+                passwordType: "pw",
+                salt: CoreBuffer.fromUtf8("a16byteslongsalt"),
+                passwordLocationIndicator: 4
+            })
+        });
+
+        expect(reference.toUrl()).toBe(
+            "https://backbone.example.com/r/ANID1234#M3xsZXJKeVg4eWRKREVYb3dxMlBNTW50UlhYQTI3d2dISllBX0JqbkZ4NTVZfHxwdyZZVEUyWW5sMFpYTnNiMjVuYzJGc2RBPT0mNA"
+        );
+    });
+
     test("from with a url reference", () => {
         const reference = Reference.from("https://backbone.example.com/r/ANID1234#M3xsZXJKeVg4eWRKREVYb3dxMlBNTW50UlhYQTI3d2dISllBX0JqbkZ4NTVZfHw");
 


### PR DESCRIPTION
# Readiness checklist

- [x] I added/updated tests.
- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

<!-- # Description -->
