### PR TITLE
Re-add `processDeviceOnboardingReference` to the AppStringProcessor

### DIFF
--- a/packages/app-runtime/src/AppStringProcessor.ts
+++ b/packages/app-runtime/src/AppStringProcessor.ts
@@ -2,7 +2,7 @@ import { ILogger, ILoggerFactory } from "@js-soft/logging-abstractions";
 import { Serializable } from "@js-soft/ts-serval";
 import { EventBus, Result } from "@js-soft/ts-utils";
 import { ICoreAddress, Reference, SharedPasswordProtection } from "@nmshd/core-types";
-import { AnonymousServices, RuntimeServices } from "@nmshd/runtime";
+import { AnonymousServices, DeviceMapper, RuntimeServices } from "@nmshd/runtime";
 import { BackboneIds, TokenContentDeviceSharedSecret } from "@nmshd/transport";
 import { AppRuntimeErrors } from "./AppRuntimeErrors";
 import { IUIBridge } from "./extensibility";
@@ -139,6 +139,43 @@ export class AppStringProcessor {
                 return Result.fail(AppRuntimeErrors.appStringProcessor.deviceOnboardingNotAllowed());
         }
 
+        return Result.ok(undefined);
+    }
+
+    public async processDeviceOnboardingReference(url: string): Promise<Result<void>> {
+        url = url.trim();
+
+        let reference: Reference;
+
+        try {
+            reference = Reference.from(url);
+        } catch (_) {
+            return Result.fail(AppRuntimeErrors.appStringProcessor.invalidReference());
+        }
+
+        if (!BackboneIds.token.validate(reference.id)) return Result.fail(AppRuntimeErrors.appStringProcessor.noDeviceOnboardingCode());
+
+        const tokenResultHolder = reference.passwordProtection
+            ? await this._fetchPasswordProtectedItemWithRetry(
+                  async (password) => await this.runtime.anonymousServices.tokens.loadPeerToken({ reference: reference.truncate(), password }),
+                  reference.passwordProtection
+              )
+            : { result: await this.runtime.anonymousServices.tokens.loadPeerToken({ reference: reference.truncate() }) };
+
+        if (tokenResultHolder.result.isError && tokenResultHolder.result.error.equals(AppRuntimeErrors.appStringProcessor.passwordNotProvided())) {
+            return Result.ok(undefined);
+        }
+
+        if (tokenResultHolder.result.isError) {
+            return Result.fail(tokenResultHolder.result.error);
+        }
+
+        const tokenDTO = tokenResultHolder.result.value;
+        const tokenContent = this.parseTokenContent(tokenDTO.content);
+        if (!(tokenContent instanceof TokenContentDeviceSharedSecret)) return Result.fail(AppRuntimeErrors.appStringProcessor.noDeviceOnboardingCode());
+
+        const uiBridge = await this.runtime.uiBridge();
+        await uiBridge.showDeviceOnboarding(DeviceMapper.toDeviceOnboardingInfoDTO(tokenContent.sharedSecret));
         return Result.ok(undefined);
     }
 

--- a/packages/app-runtime/test/runtime/AppStringProcessor.test.ts
+++ b/packages/app-runtime/test/runtime/AppStringProcessor.test.ts
@@ -1,6 +1,6 @@
 import { ArbitraryRelationshipTemplateContentJSON, AuthenticationRequestItem, RelationshipTemplateContent } from "@nmshd/content";
 import { CoreDate, PasswordLocationIndicatorOptions } from "@nmshd/core-types";
-import { PeerRelationshipTemplateLoadedEvent } from "@nmshd/runtime";
+import { DeviceOnboardingInfoDTO, PeerRelationshipTemplateLoadedEvent } from "@nmshd/runtime";
 import assert from "assert";
 import { AppRuntime, LocalAccountSession } from "../../src";
 import { MockEventBus, MockUIBridge, TestUtil } from "../lib";
@@ -220,6 +220,115 @@ describe("AppStringProcessor", function () {
         await runtime2.stringProcessor.processReference(templateResult.value.reference.truncated);
 
         expect(mockUiBridge).enterPasswordCalled("pw", undefined, undefined, 50);
+    });
+
+    describe("onboarding", function () {
+        let runtime3: AppRuntime;
+        const runtime3MockUiBridge = new MockUIBridge();
+
+        beforeAll(async function () {
+            runtime3 = await TestUtil.createRuntime(undefined, runtime3MockUiBridge, eventBus);
+            await runtime3.start();
+        });
+
+        afterAll(async () => await runtime3.stop());
+
+        test("backup device onboarding with a password protected Token", async function () {
+            const tokenResult = await runtime1Session.transportServices.identityRecoveryKits.createIdentityRecoveryKit({
+                profileName: "profileNameForBackupDevice",
+                passwordProtection: { password: "password" }
+            });
+
+            mockUiBridge.setPasswordToReturnForAttempt(1, "password");
+
+            const result = await runtime2.stringProcessor.processDeviceOnboardingReference(tokenResult.value.reference.truncated);
+            expect(result).toBeSuccessful();
+            expect(result.value).toBeUndefined();
+
+            expect(mockUiBridge).showDeviceOnboardingCalled((deviceOnboardingInfo: DeviceOnboardingInfoDTO) => deviceOnboardingInfo.isBackupDevice);
+        });
+
+        describe("invalid references", function () {
+            test("device onboarding with a truncated relationship template reference", async function () {
+                const templateResult = await runtime1Session.transportServices.relationshipTemplates.createOwnRelationshipTemplate({
+                    content: templateContent,
+                    expiresAt: CoreDate.utc().add({ days: 1 }).toISOString(),
+                    passwordProtection: { password: "password" }
+                });
+
+                const result = await runtime2.stringProcessor.processDeviceOnboardingReference(templateResult.value.reference.truncated);
+                expect(result.isError).toBe(true);
+
+                expect(result.error.code).toBe("error.appruntime.appStringProcessor.noDeviceOnboardingCode");
+
+                expect(mockUiBridge).enterPasswordNotCalled();
+                expect(mockUiBridge).requestAccountSelectionNotCalled();
+            });
+
+            test("device onboarding with a url relationship template reference", async function () {
+                const templateResult = await runtime1Session.transportServices.relationshipTemplates.createOwnRelationshipTemplate({
+                    content: templateContent,
+                    expiresAt: CoreDate.utc().add({ days: 1 }).toISOString(),
+                    passwordProtection: { password: "password" }
+                });
+
+                const result = await runtime2.stringProcessor.processDeviceOnboardingReference(templateResult.value.reference.url);
+                expect(result.isError).toBe(true);
+
+                expect(result.error.code).toBe("error.appruntime.appStringProcessor.noDeviceOnboardingCode");
+
+                expect(mockUiBridge).enterPasswordNotCalled();
+                expect(mockUiBridge).requestAccountSelectionNotCalled();
+            });
+
+            test("device onboarding with a truncated relationship template token reference", async function () {
+                const templateResult = await runtime1Session.transportServices.relationshipTemplates.createOwnRelationshipTemplate({
+                    content: templateContent,
+                    expiresAt: CoreDate.utc().add({ days: 1 }).toISOString(),
+                    passwordProtection: { password: "password" }
+                });
+
+                mockUiBridge.setPasswordToReturnForAttempt(1, "password");
+
+                const tokenResult = await runtime1Session.transportServices.relationshipTemplates.createTokenForOwnRelationshipTemplate({
+                    templateId: templateResult.value.id,
+                    ephemeral: true,
+                    passwordProtection: { password: "password" }
+                });
+
+                const result = await runtime2.stringProcessor.processDeviceOnboardingReference(tokenResult.value.reference.truncated);
+                expect(result.isError).toBe(true);
+
+                expect(result.error.code).toBe("error.appruntime.appStringProcessor.noDeviceOnboardingCode");
+
+                expect(mockUiBridge).enterPasswordCalled("pw");
+                expect(mockUiBridge).requestAccountSelectionNotCalled();
+            });
+
+            test("device onboarding with a url relationship template token reference", async function () {
+                const templateResult = await runtime1Session.transportServices.relationshipTemplates.createOwnRelationshipTemplate({
+                    content: templateContent,
+                    expiresAt: CoreDate.utc().add({ days: 1 }).toISOString(),
+                    passwordProtection: { password: "password" }
+                });
+
+                mockUiBridge.setPasswordToReturnForAttempt(1, "password");
+
+                const tokenResult = await runtime1Session.transportServices.relationshipTemplates.createTokenForOwnRelationshipTemplate({
+                    templateId: templateResult.value.id,
+                    ephemeral: true,
+                    passwordProtection: { password: "password" }
+                });
+
+                const result = await runtime2.stringProcessor.processDeviceOnboardingReference(tokenResult.value.reference.url);
+                expect(result.isError).toBe(true);
+
+                expect(result.error.code).toBe("error.appruntime.appStringProcessor.noDeviceOnboardingCode");
+
+                expect(mockUiBridge).enterPasswordCalled("pw");
+                expect(mockUiBridge).requestAccountSelectionNotCalled();
+            });
+        });
     });
 
     describe("url processing", function () {


### PR DESCRIPTION
# Readiness checklist

- [ ] I added/updated tests.
- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

# Description

I deleted this functionality in #750 but we need it to scan recovery kits.