### PR TITLE
Notify peers about Attribute deletion if only predecessor was shared

### DIFF
--- a/packages/runtime/src/useCases/common/RuntimeErrors.ts
+++ b/packages/runtime/src/useCases/common/RuntimeErrors.ts
@@ -245,10 +245,10 @@ class Attributes {
         return new ApplicationError("error.runtime.attributes.setDefaultOwnIdentityAttributesIsDisabled", "Setting default OwnIdentityAttributes is disabled for this Account.");
     }
 
-    public cannotDeleteSharedAttributeWhileRelationshipIsPending(): ApplicationError {
+    public cannotDeleteSharedAttributeWhileRelationshipIsPending(attributeId: CoreId | string): ApplicationError {
         return new ApplicationError(
             "error.runtime.attributes.cannotDeleteSharedAttributeWhileRelationshipIsPending",
-            "The shared Attribute cannot be deleted while the Relationship to the peer is in status 'Pending'. If you want to delete it now, you'll have to accept, reject or revoke the pending Relationship."
+            `The shared Attribute '${attributeId.toString()}' cannot be deleted while the Relationship to a peer is in status 'Pending'. If you want to delete it now, you'll have to accept, reject or revoke the pending Relationship.`
         );
     }
 }

--- a/packages/runtime/src/useCases/consumption/attributes/DeleteAttributeAndNotify.ts
+++ b/packages/runtime/src/useCases/consumption/attributes/DeleteAttributeAndNotify.ts
@@ -172,6 +172,8 @@ export class DeleteAttributeAndNotifyUseCase extends UseCase<DeleteAttributeAndN
     }
 
     private async notifyPeersOfAttribute(attribute: LocalAttribute, peers: CoreAddress[]): Promise<string[]> {
+        if (peers.length === 0) return [];
+
         const notificationItem = this.createAttributeDeletedNotificationItem(attribute);
 
         const notificationIdsOfAttribute = [];
@@ -184,6 +186,8 @@ export class DeleteAttributeAndNotifyUseCase extends UseCase<DeleteAttributeAndN
     }
 
     private async notifyPeersOfPredecessors(attribute: LocalAttribute, peersOfPredecessors: [CoreAddress, CoreId][]): Promise<string[]> {
+        if (peersOfPredecessors.length === 0) return [];
+
         const notificationIdsOfPredecessors = [];
         for (const [peer, predecessorId] of peersOfPredecessors) {
             const notificationItem = this.createAttributeDeletedNotificationItem(attribute, predecessorId);

--- a/packages/runtime/src/useCases/consumption/attributes/DeleteAttributeAndNotify.ts
+++ b/packages/runtime/src/useCases/consumption/attributes/DeleteAttributeAndNotify.ts
@@ -46,7 +46,6 @@ export class DeleteAttributeAndNotifyUseCase extends UseCase<DeleteAttributeAndN
         super(validator);
     }
 
-    // TODO: what if only predecessor was shared -> different PR
     protected async executeInternal(request: DeleteAttributeAndNotifyRequest): Promise<Result<DeleteAttributeAndNotifyResponse>> {
         const attribute = await this.attributesController.getLocalAttribute(CoreId.from(request.attributeId));
         if (!attribute) return Result.fail(RuntimeErrors.general.recordNotFound(LocalAttribute));
@@ -54,20 +53,22 @@ export class DeleteAttributeAndNotifyUseCase extends UseCase<DeleteAttributeAndN
         const validationResult = await this.attributesController.validateFullAttributeDeletionProcess(attribute);
         if (validationResult.isError()) return Result.fail(validationResult.error);
 
-        const getPeersToNotifyResult = await this.getPeersToNotify(attribute);
-        if (getPeersToNotifyResult.isError) return Result.fail(getPeersToNotifyResult.error);
+        const peersOfAttributeResult = await this.getPeersOfAttributeToNotify(attribute);
+        if (peersOfAttributeResult.isError) return Result.fail(peersOfAttributeResult.error);
+
+        const peersOfOnlyPredecessorResult = await this.getPeersOfPredecessorsToNotify(attribute);
+        if (peersOfOnlyPredecessorResult.isError) return Result.fail(peersOfOnlyPredecessorResult.error);
 
         await this.attributesController.executeFullAttributeDeletionProcess(attribute);
 
-        const notificationItem = this.createAttributeDeletedNotificationItem(attribute);
-        const notificationIds = await this.notifyPeers(getPeersToNotifyResult.value, notificationItem);
+        const notificationIds = await this.notifyPeers(attribute, peersOfAttributeResult.value, peersOfOnlyPredecessorResult.value);
 
         await this.accountController.syncDatawallet();
 
         return Result.ok({ notificationIds });
     }
 
-    private async getPeersToNotify(attribute: LocalAttribute): Promise<Result<CoreAddress[]>> {
+    private async getPeersOfAttributeToNotify(attribute: LocalAttribute): Promise<Result<CoreAddress[]>> {
         const attributeType = (attribute.constructor as any).name;
         switch (attributeType) {
             case OwnIdentityAttribute.name:
@@ -107,7 +108,7 @@ export class DeleteAttributeAndNotifyUseCase extends UseCase<DeleteAttributeAndN
         if (relationshipsToNotify.length === 0) return Result.ok([]);
 
         if (relationshipsToNotify.some((relationship) => relationship.status === RelationshipStatus.Pending)) {
-            return Result.fail(RuntimeErrors.attributes.cannotDeleteSharedAttributeWhileRelationshipIsPending());
+            return Result.fail(RuntimeErrors.attributes.cannotDeleteSharedAttributeWhileRelationshipIsPending(attribute.id));
         }
 
         const peersToNotify = relationshipsToNotify.map((relationship) => relationship.peer.address);
@@ -128,44 +129,99 @@ export class DeleteAttributeAndNotifyUseCase extends UseCase<DeleteAttributeAndN
         }
 
         if (relationship.status === RelationshipStatus.Pending) {
-            return Result.fail(RuntimeErrors.attributes.cannotDeleteSharedAttributeWhileRelationshipIsPending());
+            return Result.fail(RuntimeErrors.attributes.cannotDeleteSharedAttributeWhileRelationshipIsPending(attribute.id));
         }
 
         return Result.ok([peer]);
     }
 
+    private async getPeersOfPredecessorsToNotify(attribute: LocalAttribute): Promise<Result<[CoreAddress, CoreId][]>> {
+        if (!(attribute instanceof OwnIdentityAttribute || attribute instanceof OwnRelationshipAttribute || attribute instanceof PeerRelationshipAttribute)) {
+            return Result.ok([]);
+        }
+
+        const peersWithPredecessors = await this.attributesController.getPeersWithExclusivelyForwardedPredecessors(attribute.id);
+        if (peersWithPredecessors.length === 0) return Result.ok([]);
+
+        const peersWithPredecessorsToNotify: [CoreAddress, CoreId][] = [];
+        for (const [peer, attributeId] of peersWithPredecessors) {
+            const relationship = await this.relationshipsController.getRelationshipToIdentity(peer);
+            if (
+                !relationship ||
+                relationship.peerDeletionInfo?.deletionStatus === PeerDeletionStatus.Deleted ||
+                ![RelationshipStatus.Pending, RelationshipStatus.Active, RelationshipStatus.Terminated].includes(relationship.status)
+            ) {
+                continue;
+            }
+
+            if (relationship.status === RelationshipStatus.Pending) {
+                return Result.fail(RuntimeErrors.attributes.cannotDeleteSharedAttributeWhileRelationshipIsPending(attributeId));
+            }
+
+            peersWithPredecessorsToNotify.push([peer, attributeId]);
+        }
+
+        return Result.ok(peersWithPredecessorsToNotify);
+    }
+
+    private async notifyPeers(attribute: LocalAttribute, peersOfAttribute: CoreAddress[], peersOfPredecessors: [CoreAddress, CoreId][]): Promise<string[]> {
+        const notificationIdsOfAttribute = await this.notifyPeersOfAttribute(attribute, peersOfAttribute);
+        const notificationIdsOfPredecessors = await this.notifyPeersOfPredecessors(attribute, peersOfPredecessors);
+
+        return [...notificationIdsOfAttribute, ...notificationIdsOfPredecessors];
+    }
+
+    private async notifyPeersOfAttribute(attribute: LocalAttribute, peers: CoreAddress[]): Promise<string[]> {
+        const notificationItem = this.createAttributeDeletedNotificationItem(attribute);
+
+        const notificationIdsOfAttribute = [];
+        for (const peer of peers) {
+            const notificationId = await this.sendNotification(peer, notificationItem);
+            notificationIdsOfAttribute.push(notificationId);
+        }
+
+        return notificationIdsOfAttribute;
+    }
+
+    private async notifyPeersOfPredecessors(attribute: LocalAttribute, peersOfPredecessors: [CoreAddress, CoreId][]): Promise<string[]> {
+        const notificationIdsOfPredecessors = [];
+        for (const [peer, predecessorId] of peersOfPredecessors) {
+            const notificationItem = this.createAttributeDeletedNotificationItem(attribute, predecessorId);
+            const notificationId = await this.sendNotification(peer, notificationItem);
+            notificationIdsOfPredecessors.push(notificationId);
+        }
+
+        return notificationIdsOfPredecessors;
+    }
+
     private createAttributeDeletedNotificationItem(
-        attribute: LocalAttribute
+        attribute: LocalAttribute,
+        predecessorId?: CoreId
     ): OwnAttributeDeletedByOwnerNotificationItem | PeerRelationshipAttributeDeletedByPeerNotificationItem | ForwardedAttributeDeletedByPeerNotificationItem {
         const attributeType = (attribute.constructor as any).name;
         switch (attributeType) {
             case OwnIdentityAttribute.name:
             case OwnRelationshipAttribute.name:
-                return OwnAttributeDeletedByOwnerNotificationItem.from({ attributeId: attribute.id });
+                return OwnAttributeDeletedByOwnerNotificationItem.from({ attributeId: predecessorId ?? attribute.id });
             case PeerRelationshipAttribute.name:
-                return PeerRelationshipAttributeDeletedByPeerNotificationItem.from({ attributeId: attribute.id });
+                return PeerRelationshipAttributeDeletedByPeerNotificationItem.from({ attributeId: predecessorId ?? attribute.id });
             case PeerIdentityAttribute.name:
             case ThirdPartyRelationshipAttribute.name:
-                return ForwardedAttributeDeletedByPeerNotificationItem.from({ attributeId: attribute.id });
+                return ForwardedAttributeDeletedByPeerNotificationItem.from({ attributeId: predecessorId ?? attribute.id });
             default:
                 throw new Error("Type of LocalAttribute not found.");
         }
     }
 
-    private async notifyPeers(
-        peers: CoreAddress[],
+    private async sendNotification(
+        peer: CoreAddress,
         notificationItem: OwnAttributeDeletedByOwnerNotificationItem | PeerRelationshipAttributeDeletedByPeerNotificationItem | ForwardedAttributeDeletedByPeerNotificationItem
-    ): Promise<string[]> {
-        const notificationIds = [];
-        for (const peer of peers) {
-            const notificationId = await ConsumptionIds.notification.generate();
-            const notification = Notification.from({ id: notificationId, items: [notificationItem] });
+    ): Promise<string> {
+        const notificationId = await ConsumptionIds.notification.generate();
+        const notification = Notification.from({ id: notificationId, items: [notificationItem] });
 
-            await this.messageController.sendMessage({ recipients: [peer], content: notification });
+        await this.messageController.sendMessage({ recipients: [peer], content: notification });
 
-            notificationIds.push(notificationId.toString());
-        }
-
-        return notificationIds;
+        return notificationId.toString();
     }
 }

--- a/packages/runtime/test/consumption/attributes.test.ts
+++ b/packages/runtime/test/consumption/attributes.test.ts
@@ -2651,7 +2651,7 @@ describe(DeleteAttributeAndNotifyUseCase.name, () => {
 
                 const result = await services1.consumption.attributes.deleteAttributeAndNotify({ attributeId: ownIdentityAttribute.id });
                 expect(result).toBeAnError(
-                    "The shared Attribute cannot be deleted while the Relationship to the peer is in status 'Pending'. If you want to delete it now, you'll have to accept, reject or revoke the pending Relationship.",
+                    `The shared Attribute '${ownIdentityAttribute.id}' cannot be deleted while the Relationship to the peer is in status 'Pending'. If you want to delete it now, you'll have to accept, reject or revoke the pending Relationship.`,
                     "error.runtime.attributes.cannotDeleteSharedAttributeWhileRelationshipIsPending"
                 );
             });
@@ -2759,7 +2759,7 @@ describe(DeleteAttributeAndNotifyUseCase.name, () => {
 
                 const result = await services2.consumption.attributes.deleteAttributeAndNotify({ attributeId: peerIdentityAttribute.id });
                 expect(result).toBeAnError(
-                    "The shared Attribute cannot be deleted while the Relationship to the peer is in status 'Pending'. If you want to delete it now, you'll have to accept, reject or revoke the pending Relationship.",
+                    `The shared Attribute '${peerIdentityAttribute.id}' cannot be deleted while the Relationship to the peer is in status 'Pending'. If you want to delete it now, you'll have to accept, reject or revoke the pending Relationship.`,
                     "error.runtime.attributes.cannotDeleteSharedAttributeWhileRelationshipIsPending"
                 );
             });
@@ -3070,7 +3070,7 @@ describe(DeleteAttributeAndNotifyUseCase.name, () => {
 
                 const result = await services1.consumption.attributes.deleteAttributeAndNotify({ attributeId: ownRelationshipAttribute.id });
                 expect(result).toBeAnError(
-                    "The shared Attribute cannot be deleted while the Relationship to the peer is in status 'Pending'. If you want to delete it now, you'll have to accept, reject or revoke the pending Relationship.",
+                    `The shared Attribute '${ownRelationshipAttribute.id}' cannot be deleted while the Relationship to the peer is in status 'Pending'. If you want to delete it now, you'll have to accept, reject or revoke the pending Relationship.`,
                     "error.runtime.attributes.cannotDeleteSharedAttributeWhileRelationshipIsPending"
                 );
             });
@@ -3257,7 +3257,7 @@ describe(DeleteAttributeAndNotifyUseCase.name, () => {
 
                 const result = await services1.consumption.attributes.deleteAttributeAndNotify({ attributeId: peerRelationshipAttribute.id });
                 expect(result).toBeAnError(
-                    "The shared Attribute cannot be deleted while the Relationship to the peer is in status 'Pending'. If you want to delete it now, you'll have to accept, reject or revoke the pending Relationship.",
+                    `The shared Attribute '${peerRelationshipAttribute.id}' cannot be deleted while the Relationship to the peer is in status 'Pending'. If you want to delete it now, you'll have to accept, reject or revoke the pending Relationship.`,
                     "error.runtime.attributes.cannotDeleteSharedAttributeWhileRelationshipIsPending"
                 );
             });
@@ -3441,7 +3441,7 @@ describe(DeleteAttributeAndNotifyUseCase.name, () => {
 
                 const result = await services3.consumption.attributes.deleteAttributeAndNotify({ attributeId: thirdPartyRelationshipAttribute.id });
                 expect(result).toBeAnError(
-                    "The shared Attribute cannot be deleted while the Relationship to the peer is in status 'Pending'. If you want to delete it now, you'll have to accept, reject or revoke the pending Relationship.",
+                    `The shared Attribute '${thirdPartyRelationshipAttribute.id}' cannot be deleted while the Relationship to the peer is in status 'Pending'. If you want to delete it now, you'll have to accept, reject or revoke the pending Relationship.`,
                     "error.runtime.attributes.cannotDeleteSharedAttributeWhileRelationshipIsPending"
                 );
             });

--- a/packages/runtime/test/consumption/attributes.test.ts
+++ b/packages/runtime/test/consumption/attributes.test.ts
@@ -2651,7 +2651,7 @@ describe(DeleteAttributeAndNotifyUseCase.name, () => {
 
                 const result = await services1.consumption.attributes.deleteAttributeAndNotify({ attributeId: ownIdentityAttribute.id });
                 expect(result).toBeAnError(
-                    `The shared Attribute '${ownIdentityAttribute.id}' cannot be deleted while the Relationship to the peer is in status 'Pending'. If you want to delete it now, you'll have to accept, reject or revoke the pending Relationship.`,
+                    `The shared Attribute '${ownIdentityAttribute.id}' cannot be deleted while the Relationship to a peer is in status 'Pending'. If you want to delete it now, you'll have to accept, reject or revoke the pending Relationship.`,
                     "error.runtime.attributes.cannotDeleteSharedAttributeWhileRelationshipIsPending"
                 );
             });
@@ -2759,7 +2759,7 @@ describe(DeleteAttributeAndNotifyUseCase.name, () => {
 
                 const result = await services2.consumption.attributes.deleteAttributeAndNotify({ attributeId: peerIdentityAttribute.id });
                 expect(result).toBeAnError(
-                    `The shared Attribute '${peerIdentityAttribute.id}' cannot be deleted while the Relationship to the peer is in status 'Pending'. If you want to delete it now, you'll have to accept, reject or revoke the pending Relationship.`,
+                    `The shared Attribute '${peerIdentityAttribute.id}' cannot be deleted while the Relationship to a peer is in status 'Pending'. If you want to delete it now, you'll have to accept, reject or revoke the pending Relationship.`,
                     "error.runtime.attributes.cannotDeleteSharedAttributeWhileRelationshipIsPending"
                 );
             });
@@ -3070,7 +3070,7 @@ describe(DeleteAttributeAndNotifyUseCase.name, () => {
 
                 const result = await services1.consumption.attributes.deleteAttributeAndNotify({ attributeId: ownRelationshipAttribute.id });
                 expect(result).toBeAnError(
-                    `The shared Attribute '${ownRelationshipAttribute.id}' cannot be deleted while the Relationship to the peer is in status 'Pending'. If you want to delete it now, you'll have to accept, reject or revoke the pending Relationship.`,
+                    `The shared Attribute '${ownRelationshipAttribute.id}' cannot be deleted while the Relationship to a peer is in status 'Pending'. If you want to delete it now, you'll have to accept, reject or revoke the pending Relationship.`,
                     "error.runtime.attributes.cannotDeleteSharedAttributeWhileRelationshipIsPending"
                 );
             });
@@ -3257,7 +3257,7 @@ describe(DeleteAttributeAndNotifyUseCase.name, () => {
 
                 const result = await services1.consumption.attributes.deleteAttributeAndNotify({ attributeId: peerRelationshipAttribute.id });
                 expect(result).toBeAnError(
-                    `The shared Attribute '${peerRelationshipAttribute.id}' cannot be deleted while the Relationship to the peer is in status 'Pending'. If you want to delete it now, you'll have to accept, reject or revoke the pending Relationship.`,
+                    `The shared Attribute '${peerRelationshipAttribute.id}' cannot be deleted while the Relationship to a peer is in status 'Pending'. If you want to delete it now, you'll have to accept, reject or revoke the pending Relationship.`,
                     "error.runtime.attributes.cannotDeleteSharedAttributeWhileRelationshipIsPending"
                 );
             });
@@ -3441,7 +3441,7 @@ describe(DeleteAttributeAndNotifyUseCase.name, () => {
 
                 const result = await services3.consumption.attributes.deleteAttributeAndNotify({ attributeId: thirdPartyRelationshipAttribute.id });
                 expect(result).toBeAnError(
-                    `The shared Attribute '${thirdPartyRelationshipAttribute.id}' cannot be deleted while the Relationship to the peer is in status 'Pending'. If you want to delete it now, you'll have to accept, reject or revoke the pending Relationship.`,
+                    `The shared Attribute '${thirdPartyRelationshipAttribute.id}' cannot be deleted while the Relationship to a peer is in status 'Pending'. If you want to delete it now, you'll have to accept, reject or revoke the pending Relationship.`,
                     "error.runtime.attributes.cannotDeleteSharedAttributeWhileRelationshipIsPending"
                 );
             });

--- a/packages/runtime/test/consumption/attributes.test.ts
+++ b/packages/runtime/test/consumption/attributes.test.ts
@@ -2571,6 +2571,41 @@ describe(DeleteAttributeAndNotifyUseCase.name, () => {
                 ).toBe(true);
             });
 
+            test("should notify about deletion of succeeded OwnIdentityAttribute if successor wasn't shared", async () => {
+                const ownIdentityAttributeVersion2 = (
+                    await services1.consumption.attributes.succeedOwnIdentityAttribute({
+                        predecessorId: ownIdentityAttributeVersion1.id,
+                        successorContent: {
+                            value: {
+                                "@type": "GivenName",
+                                value: "aThirdGivenName"
+                            }
+                        }
+                    })
+                ).value.successor;
+
+                const notificationIds = (await services1.consumption.attributes.deleteAttributeAndNotify({ attributeId: ownIdentityAttributeVersion2.id })).value.notificationIds;
+
+                const timeBeforeUpdate = CoreDate.utc();
+                await syncUntilHasMessageWithNotification(services2.transport, notificationIds[0]);
+                await services2.eventBus.waitForEvent(OwnAttributeDeletedByOwnerEvent, (e) => {
+                    return e.data.id.toString() === ownIdentityAttributeVersion1.id;
+                });
+                const timeAfterUpdate = CoreDate.utc();
+
+                const updatedPeerIdentityAttributeVersion1 = (await services2.consumption.attributes.getAttribute({ id: peerIdentityAttributeVersion1.id })).value;
+                expect(updatedPeerIdentityAttributeVersion1.peerSharingDetails!.deletionInfo!.deletionStatus).toBe("DeletedByEmitter");
+                expect(CoreDate.from(updatedPeerIdentityAttributeVersion1.peerSharingDetails!.deletionInfo!.deletionDate).isBetween(timeBeforeUpdate, timeAfterUpdate.add(1))).toBe(
+                    true
+                );
+
+                const updatedPeerIdentityAttributeVersion0 = (await services2.consumption.attributes.getAttribute({ id: peerIdentityAttributeVersion0.id })).value;
+                expect(updatedPeerIdentityAttributeVersion0.peerSharingDetails!.deletionInfo!.deletionStatus).toBe("DeletedByEmitter");
+                expect(CoreDate.from(updatedPeerIdentityAttributeVersion1.peerSharingDetails!.deletionInfo!.deletionDate).isBetween(timeBeforeUpdate, timeAfterUpdate.add(1))).toBe(
+                    true
+                );
+            });
+
             test("should throw trying to call with an unknown attribute ID", async () => {
                 const unknownAttributeId = "ATTxxxxxxxxxxxxxxxxx";
                 const result = await services1.consumption.attributes.deleteAttributeAndNotify({ attributeId: unknownAttributeId });
@@ -2845,7 +2880,7 @@ describe(DeleteAttributeAndNotifyUseCase.name, () => {
                 requestParamsForAnotherRelationshipAttribute,
                 forwardedPeerRelationshipAttributeVersion0.id
             );
-            forwardedPeerRelationshipAttributeVersion0 = await executeFullRequestAndAcceptExistingAttributeFlow(
+            forwardedPeerRelationshipAttributeVersion1 = await executeFullRequestAndAcceptExistingAttributeFlow(
                 services2,
                 services3,
                 requestParamsForAnotherRelationshipAttribute,
@@ -2854,7 +2889,7 @@ describe(DeleteAttributeAndNotifyUseCase.name, () => {
 
             thirdPartyRelationshipAttributeForwardedByPeerVersion0 = (await services3.consumption.attributes.getAttribute({ id: forwardedPeerRelationshipAttributeVersion0.id }))
                 .value;
-            thirdPartyRelationshipAttributeForwardedByPeerVersion1 = (await services3.consumption.attributes.getAttribute({ id: forwardedPeerRelationshipAttributeVersion0.id }))
+            thirdPartyRelationshipAttributeForwardedByPeerVersion1 = (await services3.consumption.attributes.getAttribute({ id: forwardedPeerRelationshipAttributeVersion1.id }))
                 .value;
         });
 
@@ -2958,6 +2993,43 @@ describe(DeleteAttributeAndNotifyUseCase.name, () => {
                         timeBeforeUpdate,
                         timeAfterUpdate.add(1)
                     )
+                ).toBe(true);
+            });
+
+            test("should notify third party about deletion of succeeded OwnRelationshipAttribute if successor wasn't shared", async () => {
+                const ownRelationshipAttributeVersion2 = (
+                    await services1.consumption.attributes.succeedRelationshipAttributeAndNotifyPeer({
+                        predecessorId: ownRelationshipAttributeVersion1.id,
+                        successorContent: {
+                            value: {
+                                "@type": "ProprietaryString",
+                                value: "aThirdProprietaryString",
+                                title: "aTitle"
+                            }
+                        }
+                    })
+                ).value.successor;
+
+                const notificationIds = (await services1.consumption.attributes.deleteAttributeAndNotify({ attributeId: ownRelationshipAttributeVersion2.id })).value
+                    .notificationIds;
+
+                const timeBeforeUpdate = CoreDate.utc();
+                await syncUntilHasMessageWithNotification(services3.transport, notificationIds[1]);
+                await services3.eventBus.waitForEvent(OwnAttributeDeletedByOwnerEvent, (e) => {
+                    return e.data.id.toString() === ownRelationshipAttributeVersion1.id;
+                });
+                const timeAfterUpdate = CoreDate.utc();
+
+                const updatedThirdPartyRelationshipAttributeVersion1 = (await services3.consumption.attributes.getAttribute({ id: ownRelationshipAttributeVersion1.id })).value;
+                expect(updatedThirdPartyRelationshipAttributeVersion1.peerSharingDetails!.deletionInfo!.deletionStatus).toBe("DeletedByEmitter");
+                expect(
+                    CoreDate.from(updatedThirdPartyRelationshipAttributeVersion1.peerSharingDetails!.deletionInfo!.deletionDate).isBetween(timeBeforeUpdate, timeAfterUpdate.add(1))
+                ).toBe(true);
+
+                const updatedThirdPartyRelationshipAttributeVersion0 = (await services3.consumption.attributes.getAttribute({ id: ownRelationshipAttributeVersion0.id })).value;
+                expect(updatedThirdPartyRelationshipAttributeVersion0.peerSharingDetails!.deletionInfo!.deletionStatus).toBe("DeletedByEmitter");
+                expect(
+                    CoreDate.from(updatedThirdPartyRelationshipAttributeVersion0.peerSharingDetails!.deletionInfo!.deletionDate).isBetween(timeBeforeUpdate, timeAfterUpdate.add(1))
                 ).toBe(true);
             });
 
@@ -3106,6 +3178,45 @@ describe(DeleteAttributeAndNotifyUseCase.name, () => {
                         timeBeforeUpdate,
                         timeAfterUpdate.add(1)
                     )
+                ).toBe(true);
+            });
+
+            test("should notify third party about deletion of succeeded PeerRelationshipAttribute if successor wasn't shared", async () => {
+                const successionResult = (
+                    await services1.consumption.attributes.succeedRelationshipAttributeAndNotifyPeer({
+                        predecessorId: forwardedPeerRelationshipAttributeVersion1.id,
+                        successorContent: {
+                            value: {
+                                "@type": "ProprietaryString",
+                                value: "aForthProprietaryString",
+                                title: "aTitle"
+                            }
+                        }
+                    })
+                ).value;
+                await syncUntilHasMessageWithNotification(services2.transport, successionResult.notificationId);
+
+                const notificationIds = (await services2.consumption.attributes.deleteAttributeAndNotify({ attributeId: successionResult.successor.id })).value.notificationIds;
+
+                const timeBeforeUpdate = CoreDate.utc();
+                await syncUntilHasMessageWithNotification(services3.transport, notificationIds[1]);
+                await services3.eventBus.waitForEvent(PeerRelationshipAttributeDeletedByPeerEvent, (e) => {
+                    return e.data.id.toString() === forwardedPeerRelationshipAttributeVersion1.id;
+                });
+                const timeAfterUpdate = CoreDate.utc();
+
+                const updatedThirdPartyRelationshipAttributeVersion1 = (await services3.consumption.attributes.getAttribute({ id: forwardedPeerRelationshipAttributeVersion1.id }))
+                    .value;
+                expect(updatedThirdPartyRelationshipAttributeVersion1.peerSharingDetails!.deletionInfo!.deletionStatus).toBe("DeletedByEmitter");
+                expect(
+                    CoreDate.from(updatedThirdPartyRelationshipAttributeVersion1.peerSharingDetails!.deletionInfo!.deletionDate).isBetween(timeBeforeUpdate, timeAfterUpdate.add(1))
+                ).toBe(true);
+
+                const updatedThirdPartyRelationshipAttributeVersion0 = (await services3.consumption.attributes.getAttribute({ id: forwardedPeerRelationshipAttributeVersion0.id }))
+                    .value;
+                expect(updatedThirdPartyRelationshipAttributeVersion0.peerSharingDetails!.deletionInfo!.deletionStatus).toBe("DeletedByEmitter");
+                expect(
+                    CoreDate.from(updatedThirdPartyRelationshipAttributeVersion0.peerSharingDetails!.deletionInfo!.deletionDate).isBetween(timeBeforeUpdate, timeAfterUpdate.add(1))
                 ).toBe(true);
             });
 


### PR DESCRIPTION
# Readiness checklist

- [x] I added/updated tests.
- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

# Description
If we delete an Attribute, we also delete all its predecessors. Consequently, if we delete an Attribute that wasn't forwarded to a peer, but one of its predecessors was, we need to send a corresponding Notification to that peer.