### PR TITLE
Enable docker digest pinning for renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,7 +1,7 @@
 {
     $schema: "https://docs.renovatebot.com/renovate-schema.json",
     rangeStrategy: "bump",
-    extends: ["config:recommended", ":disableDependencyDashboard"],
+    extends: ["config:recommended", "docker:pinDigests", ":disableDependencyDashboard"],
     labels: ["dependencies"],
     schedule: ["after 10pm every weekday", "before 5am every weekday", "every weekend"],
     reviewers: ["jkoenig134", "Milena-Czierlinski"],


### PR DESCRIPTION
# Readiness checklist

- [ ] I added/updated tests.
- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

# Description

It's enabled in the connector repo - but not here .. weird.