### PR TITLE
The File owner is not exposed in FileDTO and FileDVO

### DIFF
--- a/packages/runtime-types/src/transport/FileDTO.ts
+++ b/packages/runtime-types/src/transport/FileDTO.ts
@@ -16,6 +16,7 @@ export interface FileDTO {
         truncated: string;
         url: string;
     };
+    owner: string;
     ownershipToken?: string;
     ownershipIsLocked?: true;
 }

--- a/packages/runtime/src/dataViews/DataViewExpander.ts
+++ b/packages/runtime/src/dataViews/DataViewExpander.ts
@@ -1917,6 +1917,7 @@ export class DataViewExpander {
             filename: file.filename,
             filesize: file.filesize,
             createdBy: await this.expandAddress(file.createdBy),
+            owner: await this.expandAddress(file.owner),
             reference: file.reference
         };
     }

--- a/packages/runtime/src/dataViews/transport/FileDVO.ts
+++ b/packages/runtime/src/dataViews/transport/FileDVO.ts
@@ -17,4 +17,5 @@ export interface FileDVO extends DataViewObject {
         truncated: string;
         url: string;
     };
+    owner: IdentityDVO;
 }

--- a/packages/runtime/src/useCases/transport/files/FileMapper.ts
+++ b/packages/runtime/src/useCases/transport/files/FileMapper.ts
@@ -45,6 +45,7 @@ export class FileMapper {
                 truncated: reference.truncate(),
                 url: reference.toUrl()
             },
+            owner: file.cache.owner.toString(),
             ownershipToken: file.ownershipToken,
             ownershipIsLocked: file.ownershipIsLocked
         };


### PR DESCRIPTION
# Readiness checklist

- [ ] I added/updated tests.
- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

# Description

The actual bug is then in the app where the creator is always displayed as the owner, which is not true if the file was transferred by a TransferFileOwnershipRI.